### PR TITLE
feat: support tiktok oauth2 credentials

### DIFF
--- a/credentials/TikTokOAuth2Api.credentials.ts
+++ b/credentials/TikTokOAuth2Api.credentials.ts
@@ -1,99 +1,108 @@
 import type {
-	IAuthenticateGeneric,
-	ICredentialDataDecryptedObject,
-	ICredentialTestRequest,
-	ICredentialType,
-	IHttpRequestHelper,
-	INodeProperties,
+        IAuthenticateGeneric,
+        ICredentialDataDecryptedObject,
+        ICredentialTestRequest,
+        ICredentialType,
+        IHttpRequestHelper,
+        INodeProperties,
 } from 'n8n-workflow';
 
 export class TikTokOAuth2Api implements ICredentialType {
-	name = 'tiktokOAuth2Api';
+        name = 'tiktokOAuth2Api';
 
-	displayName = 'TikTok OAuth2 API';
+        extends = ['oAuth2Api'];
 
-	documentationUrl = 'https://developers.tiktok.com/doc/oauth-user-access-token-management';
+        displayName = 'TikTok OAuth2 API';
 
-	icon = { light: 'file:icons/TikTok.svg', dark: 'file:icons/TikTok.dark.svg' } as const;
+        documentationUrl = 'https://developers.tiktok.com/doc/oauth-user-access-token-management';
 
-	properties: INodeProperties[] = [
-		{
-			displayName: 'Client Key',
-			name: 'clientKey',
-			type: 'string',
-			required: true,
-			default: '',
-			description: 'The unique key provided to your application in TikTok Developer portal.',
-		},
-		{
-			displayName: 'Client Secret',
-			name: 'clientSecret',
-			type: 'string',
-			typeOptions: {
-				password: true,
-			},
-			required: true,
-			default: '',
-			description: 'The secret key associated with your application.',
-		},
-		{
-			displayName: 'Redirect URI',
-			name: 'redirectUri',
-			type: 'string',
-			required: true,
-			default: '',
-			description: 'The redirect URI used in the authorization flow.',
-		},
-		{
-			displayName: 'Authorization Code',
-			name: 'authorizationCode',
-			type: 'string',
-			default: '',
-			description: 'The authorization code received after user consent. Needed for initial token request.',
-		},
-		{
-			displayName: 'Access Token',
-			name: 'accessToken',
-			type: 'hidden',
-			typeOptions: {
-				expirable: true,
-			},
-			default: '',
-		},
-		{
-			displayName: 'Refresh Token',
-			name: 'refreshToken',
-			type: 'hidden',
-			typeOptions: {
-				expirable: true,
-			},
-			default: '',
-		},
-	];
+        icon = { light: 'file:icons/TikTok.svg', dark: 'file:icons/TikTok.dark.svg' } as const;
 
-	// Function to handle pre-authentication (exchanging authorization code for access token)
-	async preAuthentication(this: IHttpRequestHelper, credentials: ICredentialDataDecryptedObject) {
-		const url = 'https://open.tiktokapis.com/v2/oauth/token/';
-		const { access_token, refresh_token } = (await this.helpers.httpRequest({
-			method: 'POST',
-			url,
-			body: {
-				client_key: credentials.clientKey,
-				client_secret: credentials.clientSecret,
-				code: credentials.authorizationCode, // The authorization code
-				grant_type: 'authorization_code',
-				redirect_uri: credentials.redirectUri,
-			},
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-		})) as { access_token: string; refresh_token: string };
-		
-		return {
-			accessToken: access_token,
-			refreshToken: refresh_token,
-		};
-	}
+        properties: INodeProperties[] = [
+                {
+                        displayName: 'Grant Type',
+                        name: 'grantType',
+                        type: 'hidden',
+                        default: 'authorizationCode',
+                },
+                {
+                        displayName: 'Authorization URL',
+                        name: 'authUrl',
+                        type: 'hidden',
+                        default: 'https://www.tiktok.com/v2/auth/authorize/',
+                },
+                {
+                        displayName: 'Access Token URL',
+                        name: 'accessTokenUrl',
+                        type: 'hidden',
+                        default: 'https://open.tiktokapis.com/v2/oauth/token/',
+                },
+                {
+                        displayName: 'Client Key',
+                        name: 'clientId',
+                        type: 'string',
+                        required: true,
+                        default: '',
+                        description: 'The unique key provided to your application in TikTok Developer portal.',
+                },
+                {
+                        displayName: 'Client Secret',
+                        name: 'clientSecret',
+                        type: 'string',
+                        typeOptions: {
+                                password: true,
+                        },
+                        required: true,
+                        default: '',
+                        description: 'The secret key associated with your application.',
+                },
+                {
+                        displayName: 'Scope',
+                        name: 'scope',
+                        type: 'string',
+                        default: '',
+                },
+                {
+                        displayName: 'Auth URI Query Parameters',
+                        name: 'authQueryParameters',
+                        type: 'string',
+                        default: '',
+                },
+        ];
+
+        // Function to handle custom token requests using TikTok specific parameter names
+        async preAuthentication(this: IHttpRequestHelper, credentials: ICredentialDataDecryptedObject) {
+                const url = 'https://open.tiktokapis.com/v2/oauth/token/';
+                const oauthData = credentials.oauthTokenData as any;
+
+                const body: Record<string, string> = {
+                        client_key: credentials.clientId as string,
+                        client_secret: credentials.clientSecret as string,
+                };
+
+                if (oauthData?.code) {
+                        body.code = oauthData.code;
+                        body.grant_type = 'authorization_code';
+                        body.redirect_uri = oauthData.redirectUri;
+                } else {
+                        body.refresh_token = oauthData?.refreshToken as string;
+                        body.grant_type = 'refresh_token';
+                }
+
+                const { access_token, refresh_token } = (await this.helpers.httpRequest({
+                        method: 'POST',
+                        url,
+                        body,
+                        headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded',
+                        },
+                })) as { access_token: string; refresh_token: string };
+
+                return {
+                        accessToken: access_token,
+                        refreshToken: refresh_token,
+                };
+        }
 
 	// OAuth2 authenticate method using the obtained access token
 	authenticate: IAuthenticateGeneric = {


### PR DESCRIPTION
## Summary
- extend TikTok credential from generic OAuth2 to leverage n8n UX
- map client key/secret to OAuth2 token params

## Testing
- `pnpm build`
- `pnpm lint -c .eslintrc.js` *(fails: all of the files matching the glob pattern "nodes" are ignored)*

------
https://chatgpt.com/codex/tasks/task_e_689d1596f4bc83249e78afcedf9bb3f8