### PR TITLE
feat: add TikTok profile operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. The format is based on [Conventional Commits](https://www.conventionalcommits.org/) and this project uses [semantic-release](https://github.com/semantic-release/semantic-release).
+
+## 1.1.0
+### Added
+- Support for retrieving user profile information via TikTok Display API.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 The TikTok node supports the following operations:
 - **Video Post**: Upload or delete a video to/from TikTok.
 - **Photo Post**: Upload a photo to TikTok.
+- **User Profile**: Retrieve profile information and statistics for the authenticated user.
 
 ## Credentials
 
@@ -30,7 +31,7 @@ To use this node, you need to authenticate with TikTok via OAuth2.
 1. Create a TikTok Developer account and register an app.
 2. Add the **Content Posting API** product to your app.
 3. Obtain the required OAuth2 credentials for the app and configure them in n8n.
-4. Ensure your app has been approved for the `video.upload` and `video.publish` scopes.
+4. Ensure your app has been approved for the `video.upload`, `video.publish`, and Display API scopes such as `user.info.basic`, `user.info.profile`, and `user.info.stats`.
 
 For detailed instructions on obtaining the credentials, refer to the [TikTok API Documentation](https://developers.tiktok.com/doc/oauth-user-access-token-management).
 
@@ -62,3 +63,4 @@ pnpm publish  --access public
 ## Version history
 
 - **1.0.0**: Initial release with support for uploading and deleting TikTok videos and uploading photos.
+- **1.1.0**: Added Display API support to retrieve user profile information.

--- a/credentials/TikTokOAuth2Api.credentials.ts
+++ b/credentials/TikTokOAuth2Api.credentials.ts
@@ -56,12 +56,12 @@ export class TikTokOAuth2Api implements ICredentialType {
                         default: '',
                         description: 'The secret key associated with your application.',
                 },
-                {
-                        displayName: 'Scope',
-                        name: 'scope',
-                        type: 'string',
-                        default: '',
-                },
+               {
+                       displayName: 'Scope',
+                       name: 'scope',
+                       type: 'string',
+                        default: 'user.info.basic,user.info.profile,user.info.stats',
+               },
                 {
                         displayName: 'Auth URI Query Parameters',
                         name: 'authQueryParameters',

--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -13,6 +13,7 @@ import {
 
 import { videoPostFields, videoPostOperations } from './VideoPostDescription'; // Assume VideoPostDescription file handles video posting
 import { photoPostFields, photoPostOperations } from './PhotoPostDescription'; // Assume PhotoPostDescription file handles photo posting
+import { userProfileFields, userProfileOperations } from './UserProfileDescription';
 
 import {
 	tiktokApiRequest,
@@ -25,7 +26,7 @@ export class TikTokV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 2,
-			description: 'Upload and manage TikTok videos and photos',
+                        description: 'Upload and manage TikTok videos and photos, and retrieve profile information',
 			subtitle: '={{$parameter["operation"] + ":" + $parameter["resource"]}}',
 			defaults: {
 				name: 'TikTok',
@@ -44,29 +45,37 @@ export class TikTokV2 implements INodeType {
 					name: 'resource',
 					type: 'options',
 					noDataExpression: true,
-					options: [
-						{
-							name: 'Video Post',
-							value: 'videoPost',
-							description: 'Upload a video to TikTok',
-						},
-						{
-							name: 'Photo Post',
-							value: 'photoPost',
-							description: 'Upload a photo to TikTok',
-						},
-					],
+                                        options: [
+                                                {
+                                                        name: 'Video Post',
+                                                        value: 'videoPost',
+                                                        description: 'Upload a video to TikTok',
+                                                },
+                                                {
+                                                        name: 'Photo Post',
+                                                        value: 'photoPost',
+                                                        description: 'Upload a photo to TikTok',
+                                                },
+                                                {
+                                                        name: 'User Profile',
+                                                        value: 'userProfile',
+                                                        description: 'Retrieve profile data of a TikTok user',
+                                                },
+                                        ],
 					default: 'videoPost',
 				},
-				// VIDEO POST
-				...videoPostOperations,
-				...videoPostFields,
-				// PHOTO POST
-				...photoPostOperations,
-				...photoPostFields,
-			],
-		};
-	}
+                                // VIDEO POST
+                                ...videoPostOperations,
+                                ...videoPostFields,
+                                // PHOTO POST
+                                ...photoPostOperations,
+                                ...photoPostFields,
+                                // USER PROFILE
+                                ...userProfileOperations,
+                                ...userProfileFields,
+                        ],
+                };
+        }
 
 	methods = {
 		loadOptions: {
@@ -106,15 +115,26 @@ export class TikTokV2 implements INodeType {
 					}
 				}
 
-				if (resource === 'photoPost') {
-					if (operation === 'upload') {
-						const photoUrl = this.getNodeParameter('photoUrl', i) as string;
-						const body: IDataObject = {
-							photoUrl,
-						};
-						responseData = await tiktokApiRequest.call(this, 'POST', '/photo/upload', body);
-					}
-				}
+                                if (resource === 'photoPost') {
+                                        if (operation === 'upload') {
+                                                const photoUrl = this.getNodeParameter('photoUrl', i) as string;
+                                                const body: IDataObject = {
+                                                        photoUrl,
+                                                };
+                                                responseData = await tiktokApiRequest.call(this, 'POST', '/photo/upload', body);
+                                        }
+                                }
+
+                                if (resource === 'userProfile') {
+                                        if (operation === 'get') {
+                                                const fields = this.getNodeParameter('fields', i) as string[];
+                                                const qs: IDataObject = {};
+                                                if (fields.length) {
+                                                        qs.fields = fields.join(',');
+                                                }
+                                                responseData = await tiktokApiRequest.call(this, 'GET', '/user/info/', {}, qs);
+                                        }
+                                }
 
 				const executionData = this.helpers.constructExecutionMetaData(
 					this.helpers.returnJsonArray(responseData as IDataObject[]),

--- a/nodes/TikTok/V2/UserProfileDescription.ts
+++ b/nodes/TikTok/V2/UserProfileDescription.ts
@@ -1,0 +1,81 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const userProfileOperations: INodeProperties[] = [
+        {
+                displayName: 'Operation',
+                name: 'operation',
+                type: 'options',
+                noDataExpression: true,
+                displayOptions: {
+                        show: {
+                                resource: ['userProfile'],
+                        },
+                },
+                options: [
+                        {
+                                name: 'Get',
+                                value: 'get',
+                                description: 'Get profile information for the authenticated user',
+                                action: 'Get profile',
+                        },
+                ],
+                default: 'get',
+        },
+];
+
+export const userProfileFields: INodeProperties[] = [
+        /* -------------------------------------------------------------------------- */
+        /*                                userProfile:get                             */
+        /* -------------------------------------------------------------------------- */
+        {
+                displayName: 'Fields',
+                name: 'fields',
+                type: 'multiOptions',
+                default: [],
+                displayOptions: {
+                        show: {
+                                resource: ['userProfile'],
+                                operation: ['get'],
+                        },
+                },
+                description: 'Select the profile fields to include in the response',
+                options: [
+                        {
+                                name: 'Avatar URL',
+                                value: 'avatar_url',
+                        },
+                        {
+                                name: 'Bio Description',
+                                value: 'bio_description',
+                        },
+                        {
+                                name: 'Display Name',
+                                value: 'display_name',
+                        },
+                        {
+                                name: 'Follower Count',
+                                value: 'follower_count',
+                        },
+                        {
+                                name: 'Following Count',
+                                value: 'following_count',
+                        },
+                        {
+                                name: 'Likes Count',
+                                value: 'likes_count',
+                        },
+                        {
+                                name: 'Profile Deep Link',
+                                value: 'profile_deep_link',
+                        },
+                        {
+                                name: 'Video Count',
+                                value: 'video_count',
+                        },
+                        {
+                                name: 'Username',
+                                value: 'username',
+                        },
+                ],
+        },
+];


### PR DESCRIPTION
## Summary
- add user profile operations using TikTok Display API
- default OAuth scope now includes Display API permissions
- document profile retrieval and new scopes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689d26095b488324a7735f3552608c40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a TikTok User Profile resource to retrieve profile information and stats for the authenticated user, with selectable fields.

* **Documentation**
  * Updated README with the new User Profile operation and required OAuth scopes (Display API).
  * Added version 1.1.0 entry to the changelog noting Display API profile support.

* **Chores**
  * New TikTok OAuth credentials now prefill the Scope with the required Display API permissions for easier setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->