### PR TITLE
feat: add TikTok profile operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. The format is based on [Conventional Commits](https://www.conventionalcommits.org/) and this project uses [semantic-release](https://github.com/semantic-release/semantic-release).
+
+## 1.1.0
+### Added
+- Support for retrieving user profile information via TikTok Display API.
+### Breaking
+- Default OAuth scope now requests Content Posting and Display API permissions. Reauthorize existing TikTok credentials to apply the new scopes.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 
 The TikTok node supports the following operations:
 - **Video Post**: Upload or delete a video to/from TikTok.
-- **Photo Post**: Upload a photo to TikTok.
+- **Photo Post**: Upload a photo from a verified URL to TikTok.
+- **User Profile**: Retrieve profile information and statistics for the authenticated user.
 
 ## Credentials
 
@@ -30,7 +31,9 @@ To use this node, you need to authenticate with TikTok via OAuth2.
 1. Create a TikTok Developer account and register an app.
 2. Add the **Content Posting API** product to your app.
 3. Obtain the required OAuth2 credentials for the app and configure them in n8n.
-4. Ensure your app has been approved for the `video.upload` and `video.publish` scopes.
+4. Ensure your app has been approved for the `video.upload`, `video.publish`, and Display API scopes such as `user.info.basic`, `user.info.profile`, and `user.info.stats`.
+
+> **Breaking:** Updating to v1.1.0 changes the default OAuth scopes. Reauthorize existing TikTok credentials after upgrading.
 
 For detailed instructions on obtaining the credentials, refer to the [TikTok API Documentation](https://developers.tiktok.com/doc/oauth-user-access-token-management).
 
@@ -62,3 +65,4 @@ pnpm publish  --access public
 ## Version history
 
 - **1.0.0**: Initial release with support for uploading and deleting TikTok videos and uploading photos.
+- **1.1.0**: Added Display API support to retrieve user profile information.

--- a/credentials/TikTokOAuth2Api.credentials.ts
+++ b/credentials/TikTokOAuth2Api.credentials.ts
@@ -94,10 +94,7 @@ export class TikTokOAuth2Api implements ICredentialType {
                 const { access_token, refresh_token } = (await this.helpers.httpRequest({
                         method: 'POST',
                         url,
-                        body,
-                        headers: {
-                                'Content-Type': 'application/x-www-form-urlencoded',
-                        },
+                        form: body,
                 })) as { access_token: string; refresh_token: string };
 
                 return {

--- a/credentials/TikTokOAuth2Api.credentials.ts
+++ b/credentials/TikTokOAuth2Api.credentials.ts
@@ -56,12 +56,14 @@ export class TikTokOAuth2Api implements ICredentialType {
                         default: '',
                         description: 'The secret key associated with your application.',
                 },
-                {
-                        displayName: 'Scope',
-                        name: 'scope',
-                        type: 'string',
-                        default: '',
-                },
+               {
+                       displayName: 'Scope',
+                       name: 'scope',
+                       type: 'string',
+                       default: 'video.upload,video.publish,user.info.basic,user.info.profile,user.info.stats',
+                       description:
+                               'Comma-separated OAuth scopes to request during authorization. Adjust based on the resources you plan to use.',
+               },
                 {
                         displayName: 'Auth URI Query Parameters',
                         name: 'authQueryParameters',
@@ -115,10 +117,10 @@ export class TikTokOAuth2Api implements ICredentialType {
 	};
 
 	// Credential test request to validate connection
-	test: ICredentialTestRequest = {
-		request: {
-			baseURL: 'https://open.tiktokapis.com',
-			url: '/v2/user/info/',
-		},
-	};
+        test: ICredentialTestRequest = {
+                request: {
+                        baseURL: 'https://open.tiktokapis.com',
+                        url: '/v2/user/info/?fields=username',
+                },
+        };
 }

--- a/credentials/TikTokOAuth2Api.credentials.ts
+++ b/credentials/TikTokOAuth2Api.credentials.ts
@@ -4,6 +4,7 @@ import type {
         ICredentialTestRequest,
         ICredentialType,
         IHttpRequestHelper,
+        IHttpRequestOptions,
         INodeProperties,
 } from 'n8n-workflow';
 
@@ -91,11 +92,19 @@ export class TikTokOAuth2Api implements ICredentialType {
                         body.grant_type = 'refresh_token';
                 }
 
-                const { access_token, refresh_token } = (await this.helpers.httpRequest({
-                        method: 'POST',
-                        url,
-                        form: body,
-                })) as { access_token: string; refresh_token: string };
+               const options: IHttpRequestOptions = {
+                       method: 'POST',
+                       url,
+                       headers: {
+                               'Content-Type': 'application/x-www-form-urlencoded',
+                       },
+                       body: new URLSearchParams(body).toString(),
+               };
+
+               const { access_token, refresh_token } = (await this.helpers.httpRequest(options)) as {
+                       access_token: string;
+                       refresh_token: string;
+               };
 
                 return {
                         accessToken: access_token,

--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -1,14 +1,15 @@
 import {
-	NodeConnectionType,
-	type IDataObject,
-	type IExecuteFunctions,
-	type ILoadOptionsFunctions,
-	type INodeExecutionData,
-	type INodePropertyOptions,
-	type INodeType,
-	type INodeTypeBaseDescription,
-	type INodeTypeDescription,
-	type JsonObject,
+        NodeConnectionType,
+        NodeOperationError,
+        type IDataObject,
+        type IExecuteFunctions,
+        type ILoadOptionsFunctions,
+        type INodeExecutionData,
+        type INodePropertyOptions,
+        type INodeType,
+        type INodeTypeBaseDescription,
+        type INodeTypeDescription,
+        type JsonObject,
 } from 'n8n-workflow';
 
 import { videoPostFields, videoPostOperations } from './VideoPostDescription'; // Assume VideoPostDescription file handles video posting
@@ -150,7 +151,10 @@ export class TikTokV2 implements INodeType {
                                         if (operation === 'get') {
                                                 const fields = this.getNodeParameter('fields', i) as string[];
                                                 if (!fields?.length) {
-                                                        throw new Error('User Profile: "Fields" must include at least one selection.');
+                                                        throw new NodeOperationError(
+                                                                this.getNode(),
+                                                                'User Profile: "Fields" must include at least one selection.',
+                                                        );
                                                 }
                                                 const qs: IDataObject = { fields: fields.join(',') };
                                                 responseData = await tiktokApiRequest.call(this, 'GET', '/user/info/', {}, qs);

--- a/nodes/TikTok/V2/UserProfileDescription.ts
+++ b/nodes/TikTok/V2/UserProfileDescription.ts
@@ -1,0 +1,82 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const userProfileOperations: INodeProperties[] = [
+        {
+                displayName: 'Operation',
+                name: 'operation',
+                type: 'options',
+                noDataExpression: true,
+                displayOptions: {
+                        show: {
+                                resource: ['userProfile'],
+                        },
+                },
+                options: [
+                        {
+                                name: 'Get',
+                                value: 'get',
+                                description: 'Get profile information for the authenticated user',
+                                action: 'Get profile',
+                        },
+                ],
+                default: 'get',
+        },
+];
+
+export const userProfileFields: INodeProperties[] = [
+        /* -------------------------------------------------------------------------- */
+        /*                                userProfile:get                             */
+        /* -------------------------------------------------------------------------- */
+        {
+                displayName: 'Fields',
+                name: 'fields',
+                type: 'multiOptions',
+                default: [],
+                required: true,
+                displayOptions: {
+                        show: {
+                                resource: ['userProfile'],
+                                operation: ['get'],
+                        },
+                },
+                description: 'Select the profile fields to include in the response',
+                options: [
+                        {
+                                name: 'Avatar URL',
+                                value: 'avatar_url',
+                        },
+                        {
+                                name: 'Bio Description',
+                                value: 'bio_description',
+                        },
+                        {
+                                name: 'Display Name',
+                                value: 'display_name',
+                        },
+                        {
+                                name: 'Follower Count',
+                                value: 'follower_count',
+                        },
+                        {
+                                name: 'Following Count',
+                                value: 'following_count',
+                        },
+                        {
+                                name: 'Likes Count',
+                                value: 'likes_count',
+                        },
+                        {
+                                name: 'Profile Deep Link',
+                                value: 'profile_deep_link',
+                        },
+                        {
+                                name: 'Username',
+                                value: 'username',
+                        },
+                        {
+                                name: 'Video Count',
+                                value: 'video_count',
+                        },
+                ],
+        },
+];


### PR DESCRIPTION
## Summary
- add user profile operations using TikTok Display API
- default OAuth scope now includes content posting and Display API permissions
- document profile retrieval, photo upload endpoint, and reauth requirement

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689d26095b488324a7735f3552608c40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added User Profile operation to retrieve authenticated TikTok profile details with selectable fields.
  * Enhanced Photo Post to use the v2 publish flow, mapping caption/tags into post metadata.

* **Breaking Changes**
  * Expanded default OAuth scopes to include Display API and content posting; existing TikTok connections must be reauthorized.

* **Documentation**
  * Updated README and CHANGELOG for v1.1.0 with Display API support, new operation details, and breaking notice.

* **Chores**
  * OAuth credential defaults updated to include recommended scopes; improved credential test endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->