### PR TITLE
fix: guard against undefined errors

### DIFF
--- a/nodes/TikTok/V2/GenericFunctions.ts
+++ b/nodes/TikTok/V2/GenericFunctions.ts
@@ -3,10 +3,10 @@ import type {
 	IExecuteFunctions,
 	IHookFunctions,
 	ILoadOptionsFunctions,
-	INodeParameterResourceLocator,
-	JsonObject,
-	IRequestOptions,
-	IHttpRequestMethods,
+        INodeParameterResourceLocator,
+        JsonObject,
+        IRequestOptions,
+        IHttpRequestMethods,
 } from 'n8n-workflow';
 import { ApplicationError, NodeApiError } from 'n8n-workflow';
 import { URL } from 'url';
@@ -44,9 +44,13 @@ export async function tiktokApiRequest(
 			const { data } = await this.helpers.requestOAuth2.call(this, 'tiktokOAuth2Api', options);
 			return data;
 		}
-	} catch (error) {
-		throw new NodeApiError(this.getNode(), error as JsonObject);
-	}
+        } catch (error) {
+                // Wrap unknown errors to avoid accessing properties on undefined
+                const errObject: JsonObject = error instanceof Error
+                        ? { message: error.message }
+                        : { message: String(error) };
+                throw new NodeApiError(this.getNode(), errObject);
+        }
 }
 
 export async function tiktokApiRequestAllItems(

--- a/nodes/TikTok/V2/UserProfileDescription.ts
+++ b/nodes/TikTok/V2/UserProfileDescription.ts
@@ -6,6 +6,7 @@ export const userProfileOperations: INodeProperties[] = [
                 name: 'operation',
                 type: 'options',
                 noDataExpression: true,
+                required: true,
                 displayOptions: {
                         show: {
                                 resource: ['userProfile'],
@@ -36,7 +37,6 @@ export const userProfileFields: INodeProperties[] = [
                 displayOptions: {
                         show: {
                                 resource: ['userProfile'],
-                                operation: ['get'],
                         },
                 },
                 description: 'Select the profile fields to include in the response',


### PR DESCRIPTION
## Summary
- avoid accessing properties on undefined in TikTok API helper
- ensure User Profile operation and fields display correctly

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689e0206faa883249a62a9092e495300