### PR TITLE
Rename TikTok OAuth client key field

### DIFF
--- a/credentials/TikTokOAuth2Api.credentials.ts
+++ b/credentials/TikTokOAuth2Api.credentials.ts
@@ -39,13 +39,16 @@ export class TikTokOAuth2Api implements ICredentialType {
                         default: 'https://open.tiktokapis.com/v2/oauth/token/',
                 },
                 {
-                        displayName: 'Client Key',
-                        name: 'clientId',
-                        type: 'string',
-                        required: true,
-                        default: '',
-                        description: 'The unique key provided to your application in TikTok Developer portal.',
-                },
+                       displayName: 'Client Key',
+                       name: 'clientKey',
+                       type: 'string',
+                       typeOptions: {
+                               password: true,
+                       },
+                       required: true,
+                       default: '',
+                       description: 'The unique key provided to your application in TikTok Developer portal.',
+               },
                 {
                         displayName: 'Client Secret',
                         name: 'clientSecret',
@@ -66,22 +69,22 @@ export class TikTokOAuth2Api implements ICredentialType {
                                'Comma-separated OAuth scopes to request during authorization. Adjust based on the resources you plan to use.',
                },
                 {
-                        displayName: 'Auth URI Query Parameters',
-                        name: 'authQueryParameters',
-                        type: 'hidden',
-                        default: 'client_key={{CLIENT_ID}}',
-                },
-        ];
+                       displayName: 'Auth URI Query Parameters',
+                       name: 'authQueryParameters',
+                       type: 'hidden',
+                       default: 'client_key={{CLIENT_KEY}}',
+               },
+       ];
 
         // Function to handle custom token requests using TikTok specific parameter names
         async preAuthentication(this: IHttpRequestHelper, credentials: ICredentialDataDecryptedObject) {
                 const url = 'https://open.tiktokapis.com/v2/oauth/token/';
                 const oauthData = credentials.oauthTokenData as any;
 
-                const body: Record<string, string> = {
-                        client_key: credentials.clientId as string,
-                        client_secret: credentials.clientSecret as string,
-                };
+               const body: Record<string, string> = {
+                       client_key: credentials.clientKey as string,
+                       client_secret: credentials.clientSecret as string,
+               };
 
                 if (oauthData?.code) {
                         body.code = oauthData.code;


### PR DESCRIPTION
## Summary
- rename credential field to `clientKey` and mark as password
- update auth params and token request to use TikTok `client_key`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689e1c79766c8324a2d38d45a88d6942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the “Client Key” credential input from clientId to clientKey across the integration.
  * Updated default auth query parameter to use CLIENT_KEY for alignment with the new field.
* **Bug Fixes**
  * Client Key and Client Secret inputs are now masked as passwords to prevent accidental exposure in the UI.
  * Ensures token requests use the updated Client Key field, improving consistency during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->