### PR TITLE
chore: rename user profile operation display

### DIFF
--- a/nodes/TikTok/V2/UserProfileDescription.ts
+++ b/nodes/TikTok/V2/UserProfileDescription.ts
@@ -2,7 +2,7 @@ import type { INodeProperties } from 'n8n-workflow';
 
 export const userProfileOperations: INodeProperties[] = [
         {
-                displayName: 'Action',
+                displayName: 'Operation',
                 name: 'operation',
                 type: 'options',
                 noDataExpression: true,


### PR DESCRIPTION
## Summary
- rename "Action" to "Operation" for user profile operation selector

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689e1c790a648324a7f1e1f581543db1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the UI label in the TikTok User Profile operations menu from “Action” to “Operation” for improved clarity and consistency.
  * The available option (“Get User Information”) and all behaviors remain unchanged; this is a visual text change only.
  * No impact on workflows, settings, or results—users will see the new label in the operations selector without needing to update anything.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->