### PR TITLE
feat: add follower list operations

### DIFF
--- a/nodes/TikTok/V2/FollowerDescription.ts
+++ b/nodes/TikTok/V2/FollowerDescription.ts
@@ -1,0 +1,54 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const followerOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['follower'],
+			},
+		},
+		options: [
+			{
+				name: 'List Followers',
+				value: 'listFollowers',
+				description: 'Get the list of followers of the authenticated user',
+				action: 'List followers',
+			},
+			{
+				name: 'List Following',
+				value: 'listFollowing',
+				description: 'Get the list of users the authenticated user is following',
+				action: 'List following',
+			},
+		],
+		default: 'listFollowers',
+	},
+];
+
+export const followerFields: INodeProperties[] = [
+	/* -------------------------------------------------------------------------- */
+	/*                         follower:listFollowers/listFollowing                */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Pagination Token',
+		name: 'paginationToken',
+		type: 'string',
+		default: '',
+		typeOptions: {
+			password: true,
+		},
+		displayOptions: {
+			show: {
+				resource: ['follower'],
+				operation: ['listFollowers', 'listFollowing'],
+			},
+		},
+		description:
+			'Token to specify the start page. Use the value returned from the previous request to retrieve the next page.',
+	},
+];

--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -1,24 +1,23 @@
 import {
-        NodeConnectionType,
-        NodeOperationError,
-        type IDataObject,
-        type IExecuteFunctions,
-        type ILoadOptionsFunctions,
-        type INodeExecutionData,
-        type INodePropertyOptions,
-        type INodeType,
-        type INodeTypeBaseDescription,
-        type INodeTypeDescription,
-        type JsonObject,
+	NodeConnectionType,
+	NodeOperationError,
+	type IDataObject,
+	type IExecuteFunctions,
+	type ILoadOptionsFunctions,
+	type INodeExecutionData,
+	type INodePropertyOptions,
+	type INodeType,
+	type INodeTypeBaseDescription,
+	type INodeTypeDescription,
+	type JsonObject,
 } from 'n8n-workflow';
 
 import { videoPostFields, videoPostOperations } from './VideoPostDescription'; // Assume VideoPostDescription file handles video posting
 import { photoPostFields, photoPostOperations } from './PhotoPostDescription'; // Assume PhotoPostDescription file handles photo posting
 import { userProfileFields, userProfileOperations } from './UserProfileDescription';
+import { followerFields, followerOperations } from './FollowerDescription';
 
-import {
-	tiktokApiRequest,
-} from './GenericFunctions'; // Adjusted to TikTok API helper functions
+import { tiktokApiRequest, tiktokApiRequestAllItems } from './GenericFunctions'; // Adjusted to TikTok API helper functions
 
 export class TikTokV2 implements INodeType {
 	description: INodeTypeDescription;
@@ -27,7 +26,7 @@ export class TikTokV2 implements INodeType {
 		this.description = {
 			...baseDescription,
 			version: 2,
-                        description: 'Upload and manage TikTok videos and photos, and retrieve profile information',
+			description: 'Upload and manage TikTok videos and photos, and retrieve profile information',
 			subtitle: '={{$parameter["operation"] + ":" + $parameter["resource"]}}',
 			defaults: {
 				name: 'TikTok',
@@ -46,37 +45,45 @@ export class TikTokV2 implements INodeType {
 					name: 'resource',
 					type: 'options',
 					noDataExpression: true,
-                                        options: [
-                                                {
-                                                        name: 'Video Post',
-                                                        value: 'videoPost',
-                                                        description: 'Upload a video to TikTok',
-                                                },
-                                                {
-                                                        name: 'Photo Post',
-                                                        value: 'photoPost',
-                                                        description: 'Upload a photo to TikTok',
-                                                },
-                                                {
-                                                        name: 'User Profile',
-                                                        value: 'userProfile',
-                                                        description: 'Retrieve profile data of a TikTok user',
-                                                },
-                                        ],
+					options: [
+						{
+							name: 'Video Post',
+							value: 'videoPost',
+							description: 'Upload a video to TikTok',
+						},
+						{
+							name: 'Photo Post',
+							value: 'photoPost',
+							description: 'Upload a photo to TikTok',
+						},
+						{
+							name: 'User Profile',
+							value: 'userProfile',
+							description: 'Retrieve profile data of a TikTok user',
+						},
+						{
+							name: 'Follower',
+							value: 'follower',
+							description: 'Retrieve follower and following lists',
+						},
+					],
 					default: 'videoPost',
 				},
-                                // VIDEO POST
-                                ...videoPostOperations,
-                                ...videoPostFields,
-                                // PHOTO POST
-                                ...photoPostOperations,
-                                ...photoPostFields,
-                                // USER PROFILE
-                                ...userProfileOperations,
-                                ...userProfileFields,
-                        ],
-                };
-        }
+				// VIDEO POST
+				...videoPostOperations,
+				...videoPostFields,
+				// PHOTO POST
+				...photoPostOperations,
+				...photoPostFields,
+				// USER PROFILE
+				...userProfileOperations,
+				...userProfileFields,
+				// FOLLOWER
+				...followerOperations,
+				...followerFields,
+			],
+		};
+	}
 
 	methods = {
 		loadOptions: {
@@ -116,50 +123,79 @@ export class TikTokV2 implements INodeType {
 					}
 				}
 
-                                if (resource === 'photoPost') {
-                                        if (operation === 'upload') {
-                                                const photoUrl = this.getNodeParameter('photoUrl', i) as string;
-                                                const additionalFields =
-                                                        this.getNodeParameter('additionalFields', i) as IDataObject;
-                                                const postInfo: IDataObject = {};
-                                                if (additionalFields.caption) {
-                                                        postInfo.title = additionalFields.caption as string;
-                                                }
-                                                if (additionalFields.tags) {
-                                                        postInfo.description = additionalFields.tags as string;
-                                                }
-                                                const body: IDataObject = {
-                                                        post_info: postInfo,
-                                                        source_info: {
-                                                                source: 'PULL_FROM_URL',
-                                                                photo_cover_index: 1,
-                                                                photo_images: [photoUrl],
-                                                        },
-                                                        post_mode: 'MEDIA_UPLOAD',
-                                                        media_type: 'PHOTO',
-                                                };
-                                                responseData = await tiktokApiRequest.call(
-                                                        this,
-                                                        'POST',
-                                                        '/v2/post/publish/content/init/',
-                                                        body,
-                                                );
-                                        }
-                                }
+				if (resource === 'photoPost') {
+					if (operation === 'upload') {
+						const photoUrl = this.getNodeParameter('photoUrl', i) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+						const postInfo: IDataObject = {};
+						if (additionalFields.caption) {
+							postInfo.title = additionalFields.caption as string;
+						}
+						if (additionalFields.tags) {
+							postInfo.description = additionalFields.tags as string;
+						}
+						const body: IDataObject = {
+							post_info: postInfo,
+							source_info: {
+								source: 'PULL_FROM_URL',
+								photo_cover_index: 1,
+								photo_images: [photoUrl],
+							},
+							post_mode: 'MEDIA_UPLOAD',
+							media_type: 'PHOTO',
+						};
+						responseData = await tiktokApiRequest.call(
+							this,
+							'POST',
+							'/v2/post/publish/content/init/',
+							body,
+						);
+					}
+				}
 
-                                if (resource === 'userProfile') {
-                                        if (operation === 'get') {
-                                                const fields = this.getNodeParameter('fields', i) as string[];
-                                                if (!fields?.length) {
-                                                        throw new NodeOperationError(
-                                                                this.getNode(),
-                                                                'User Profile: "Fields" must include at least one selection.',
-                                                        );
-                                                }
-                                                const qs: IDataObject = { fields: fields.join(',') };
-                                                responseData = await tiktokApiRequest.call(this, 'GET', '/user/info/', {}, qs);
-                                        }
-                                }
+				if (resource === 'userProfile') {
+					if (operation === 'get') {
+						const fields = this.getNodeParameter('fields', i) as string[];
+						if (!fields?.length) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'User Profile: "Fields" must include at least one selection.',
+							);
+						}
+						const qs: IDataObject = { fields: fields.join(',') };
+						responseData = await tiktokApiRequest.call(this, 'GET', '/user/info/', {}, qs);
+					}
+				}
+
+				if (resource === 'follower') {
+					const qs: IDataObject = {};
+					const paginationToken = this.getNodeParameter('paginationToken', i) as string;
+					if (paginationToken) {
+						qs.next_token = paginationToken;
+					}
+
+					if (operation === 'listFollowers') {
+						responseData = await tiktokApiRequestAllItems.call(
+							this,
+							'data',
+							'GET',
+							'/v2/follower/list/',
+							{},
+							qs,
+						);
+					}
+
+					if (operation === 'listFollowing') {
+						responseData = await tiktokApiRequestAllItems.call(
+							this,
+							'data',
+							'GET',
+							'/v2/following/list/',
+							{},
+							qs,
+						);
+					}
+				}
 
 				const executionData = this.helpers.constructExecutionMetaData(
 					this.helpers.returnJsonArray(responseData as IDataObject[]),


### PR DESCRIPTION
## Summary
- add follower resource with operations to list followers and following users
- implement paginated requests using `tiktokApiRequestAllItems`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689fa428554483249a6f11f000617dc8