### PR TITLE
feat: add video analytics operation

### DIFF
--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -106,15 +106,36 @@ export class TikTokV2 implements INodeType {
 
 		for (let i = 0; i < length; i++) {
 			try {
-				if (resource === 'videoPost') {
-					if (operation === 'upload') {
-						const videoFile = this.getNodeParameter('videoFile', i) as IDataObject;
-						const body: IDataObject = {
-							videoFile, // Adjust to match the TikTok video file format
-						};
-						responseData = await tiktokApiRequest.call(this, 'POST', '/video/upload', body);
-					}
-				}
+                               if (resource === 'videoPost') {
+                                       if (operation === 'upload') {
+                                               const videoFile = this.getNodeParameter('videoFile', i) as IDataObject;
+                                               const body: IDataObject = {
+                                                       videoFile, // Adjust to match the TikTok video file format
+                                               };
+                                               responseData = await tiktokApiRequest.call(this, 'POST', '/video/upload', body);
+                                       } else if (operation === 'analytics') {
+                                               const videoId = this.getNodeParameter('videoId', i) as string;
+                                               const metrics = this.getNodeParameter('metrics', i) as string[];
+                                               if (!metrics?.length) {
+                                                       throw new NodeOperationError(
+                                                               this.getNode(),
+                                                               'Video Post: "Metrics" must include at least one selection.',
+                                                               { itemIndex: i },
+                                                       );
+                                               }
+                                               const qs: IDataObject = {
+                                                       post_id: videoId,
+                                                       metrics: metrics.join(','),
+                                               };
+                                               responseData = await tiktokApiRequest.call(
+                                                       this,
+                                                       'GET',
+                                                       '/post/analytics/',
+                                                       {},
+                                                       qs,
+                                               );
+                                       }
+                               }
 
                                 if (resource === 'photoPost') {
                                         if (operation === 'upload') {
@@ -154,6 +175,7 @@ export class TikTokV2 implements INodeType {
                                                         throw new NodeOperationError(
                                                                 this.getNode(),
                                                                 'User Profile: "Fields" must include at least one selection.',
+                                                                { itemIndex: i },
                                                         );
                                                 }
                                                 const qs: IDataObject = { fields: fields.join(',') };

--- a/nodes/TikTok/V2/VideoPostDescription.ts
+++ b/nodes/TikTok/V2/VideoPostDescription.ts
@@ -18,15 +18,21 @@ export const videoPostOperations: INodeProperties[] = [
 				description: 'Upload a video to TikTok',
 				action: 'Upload video',
 			},
-			{
-				name: 'Delete',
-				value: 'delete',
-				description: 'Delete a video from TikTok',
-				action: 'Delete video',
-			},
-		],
-		default: 'upload',
-	},
+                       {
+                               name: 'Delete',
+                               value: 'delete',
+                               description: 'Delete a video from TikTok',
+                               action: 'Delete video',
+                       },
+                       {
+                               name: 'Analytics',
+                               value: 'analytics',
+                               description: 'Retrieve analytics for a TikTok video',
+                               action: 'Get video analytics',
+                       },
+               ],
+               default: 'upload',
+       },
 ];
 
 export const videoPostFields: INodeProperties[] = [
@@ -76,9 +82,9 @@ export const videoPostFields: INodeProperties[] = [
 			},
 		],
 	},
-	/* -------------------------------------------------------------------------- */
-	/*                                videoPost:delete                            */
-	/* -------------------------------------------------------------------------- */
+        /* -------------------------------------------------------------------------- */
+        /*                                videoPost:delete                            */
+        /* -------------------------------------------------------------------------- */
 	{
 		displayName: 'Video ID',
 		name: 'videoId',
@@ -91,6 +97,55 @@ export const videoPostFields: INodeProperties[] = [
 				operation: ['delete'],
 			},
 		},
-		description: 'The ID of the video to delete',
-	},
+               description: 'The ID of the video to delete',
+       },
+       /* -------------------------------------------------------------------------- */
+       /*                              videoPost:analytics                           */
+       /* -------------------------------------------------------------------------- */
+       {
+               displayName: 'Video ID',
+               name: 'videoId',
+               type: 'string',
+               default: '',
+               required: true,
+               displayOptions: {
+                       show: {
+                               resource: ['videoPost'],
+                               operation: ['analytics'],
+                       },
+               },
+               description: 'The ID of the video to retrieve analytics for',
+       },
+       {
+               displayName: 'Metrics',
+               name: 'metrics',
+               type: 'multiOptions',
+               default: [],
+               required: true,
+               displayOptions: {
+                       show: {
+                               resource: ['videoPost'],
+                               operation: ['analytics'],
+                       },
+               },
+               options: [
+                       {
+                               name: 'Views',
+                               value: 'views',
+                       },
+                       {
+                               name: 'Likes',
+                               value: 'likes',
+                       },
+                       {
+                               name: 'Comments',
+                               value: 'comments',
+                       },
+                       {
+                               name: 'Shares',
+                               value: 'shares',
+                       },
+               ],
+               description: 'Select the metrics to retrieve',
+       },
 ];


### PR DESCRIPTION
## Summary
- add Analytics operation for video posts
- implement GET /v2/post/analytics/ to retrieve selected metrics

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689fa433fc608324b3ac624d54ef267c