### PR TITLE
feat: add TikTok post retrieval

### DIFF
--- a/nodes/TikTok/V2/VideoPostDescription.ts
+++ b/nodes/TikTok/V2/VideoPostDescription.ts
@@ -24,6 +24,12 @@ export const videoPostOperations: INodeProperties[] = [
 				description: 'Delete a video from TikTok',
 				action: 'Delete video',
 			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Retrieve video metadata',
+				action: 'Get video',
+			},
 		],
 		default: 'upload',
 	},
@@ -92,5 +98,50 @@ export const videoPostFields: INodeProperties[] = [
 			},
 		},
 		description: 'The ID of the video to delete',
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                videoPost:get                               */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Video ID',
+		name: 'videoId',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['get'],
+			},
+		},
+		description: 'ID of the video to retrieve. Leave empty to list videos.',
+	},
+	{
+		displayName: 'Pagination',
+		name: 'pagination',
+		type: 'collection',
+		placeholder: 'Add Parameter',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['get'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Cursor',
+				name: 'cursor',
+				type: 'number',
+				default: 0,
+				description: 'Pagination cursor for results',
+			},
+			{
+				displayName: 'Page Size',
+				name: 'pageSize',
+				type: 'number',
+				default: 20,
+				description: 'Number of videos to return',
+			},
+		],
 	},
 ];


### PR DESCRIPTION
## Summary
- add video "get" operation with optional video id and pagination
- support TikTok post listing via `/v2/post/list/`
- output caption, status and stats for retrieved posts

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689fa437d7248324982cddcfb803b4de