### PR TITLE
chore: require n8n core 1.107.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.3.3](https://github.com/igabm/n8n-nodes-tiktok/compare/v1.3.2...v1.3.3) (2025-08-16)
+
+### Chore
+
+* require n8n >=1.107.0 for OAuth2 client credentials body properties support ([22ca768](https://github.com/n8n-io/n8n/commit/22ca768))
+
 ## [1.3.2](https://github.com/igabm/n8n-nodes-tiktok/compare/v1.3.1...v1.3.2) (2025-08-16)
 
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For detailed instructions on obtaining the credentials, refer to the [TikTok API
 
 ## Compatibility
 
-- Minimum n8n version: 0.154.0
+- Minimum n8n version: 1.107.0
 - Tested against TikTok API versions from 2023.
 
 No known incompatibility issues at this time.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "n8n": {
     "n8nNodesApiVersion": 1,
+    "minimumCoreVersion": "1.107.0",
     "credentials": [
       "dist/credentials/TikTokOAuth2Api.credentials.js"
     ],


### PR DESCRIPTION
## Summary
- require n8n >=1.107.0 for OAuth2 client credentials flow body properties support
- document new minimum n8n version in README and changelog

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689ff3681ae883248deadffc069038b6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Release
  - Published version 1.3.3.

- Chores
  - Set minimum required n8n core version to 1.107.0 for compatibility.
  - Updated internal metadata to enforce the new version requirement.
  - Added a corresponding entry to the changelog.

- Documentation
  - Updated the Compatibility section to reflect the new minimum n8n version (1.107.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->