### PR TITLE
fix: correct TikTok photo and video post payloads

### DIFF
--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -115,7 +115,7 @@ export class TikTokV2 implements INodeType {
 			try {
 				if (resource === 'videoPost') {
 					if (operation === 'upload') {
-						const videoFile = this.getNodeParameter('videoFile', i) as IDataObject;
+						const videoUrl = this.getNodeParameter('videoUrl', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
 						const postInfo: IDataObject = {};
 						if (additionalFields.title) {
@@ -144,10 +144,18 @@ export class TikTokV2 implements INodeType {
 							}
 						}
 						const body: IDataObject = {
-							videoFile, // Adjust to match the TikTok video file format
 							post_info: postInfo,
+							source_info: {
+								source: 'PULL_FROM_URL',
+								video_url: videoUrl,
+							},
 						};
-						responseData = await tiktokApiRequest.call(this, 'POST', '/video/upload', body);
+						responseData = await tiktokApiRequest.call(
+							this,
+							'POST',
+							'/post/publish/video/init/',
+							body,
+						);
 					} else if (operation === 'analytics') {
 						const videoId = this.getNodeParameter('videoId', i) as string;
 						const metrics = this.getNodeParameter('metrics', i) as string[];
@@ -197,7 +205,7 @@ export class TikTokV2 implements INodeType {
 							post_info: postInfo,
 							source_info: {
 								source: 'PULL_FROM_URL',
-								photo_cover_index: 1,
+								photo_cover_index: 0,
 								photo_images: [photoUrl],
 							},
 							post_mode: 'MEDIA_UPLOAD',

--- a/nodes/TikTok/V2/VideoPostDescription.ts
+++ b/nodes/TikTok/V2/VideoPostDescription.ts
@@ -18,21 +18,21 @@ export const videoPostOperations: INodeProperties[] = [
 				description: 'Upload a video to TikTok',
 				action: 'Upload video',
 			},
-                       {
-                               name: 'Delete',
-                               value: 'delete',
-                               description: 'Delete a video from TikTok',
-                               action: 'Delete video',
-                       },
-                       {
-                               name: 'Analytics',
-                               value: 'analytics',
-                               description: 'Retrieve analytics for a TikTok video',
-                               action: 'Get video analytics',
-                       },
-               ],
-               default: 'upload',
-       },
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a video from TikTok',
+				action: 'Delete video',
+			},
+			{
+				name: 'Analytics',
+				value: 'analytics',
+				description: 'Retrieve analytics for a TikTok video',
+				action: 'Get video analytics',
+			},
+		],
+		default: 'upload',
+	},
 ];
 
 export const videoPostFields: INodeProperties[] = [
@@ -40,8 +40,8 @@ export const videoPostFields: INodeProperties[] = [
 	/*                                videoPost:upload                            */
 	/* -------------------------------------------------------------------------- */
 	{
-		displayName: 'Video File',
-		name: 'videoFile',
+		displayName: 'Video URL',
+		name: 'videoUrl',
 		type: 'string',
 		default: '',
 		required: true,
@@ -51,7 +51,7 @@ export const videoPostFields: INodeProperties[] = [
 				operation: ['upload'],
 			},
 		},
-		description: 'The path to the video file to upload',
+		description: 'The URL of the video to upload',
 	},
 	{
 		displayName: 'Additional Fields',
@@ -65,52 +65,52 @@ export const videoPostFields: INodeProperties[] = [
 				operation: ['upload'],
 			},
 		},
-                options: [
-                        {
-                                displayName: 'Caption',
-                                name: 'caption',
-                                type: 'string',
-                                default: '',
-                                description: 'The caption for the video post',
-                        },
-                        {
-                                displayName: 'Privacy Level',
-                                name: 'privacyLevel',
-                                type: 'options',
-                                options: [
-                                        { name: 'Public', value: 'PUBLIC' },
-                                        { name: 'Friends', value: 'FRIENDS' },
-                                        { name: 'Private', value: 'PRIVATE' },
-                                ],
-                                default: 'PUBLIC',
-                                description: 'Who can view this post',
-                        },
-                        {
-                                displayName: 'Schedule Time',
-                                name: 'scheduleTime',
-                                type: 'number',
-                                default: 0,
-                                description: 'UNIX timestamp for scheduled publication',
-                        },
-                        {
-                                displayName: 'Tags',
-                                name: 'tags',
-                                type: 'string',
-                                default: '',
-                                description: 'Comma-separated list of tags for the video post',
-                        },
-                        {
-                                displayName: 'Title',
-                                name: 'title',
-                                type: 'string',
-                                default: '',
-                                description: 'The title for the video post',
-                        },
-                ],
-        },
-        /* -------------------------------------------------------------------------- */
-        /*                                videoPost:delete                            */
-        /* -------------------------------------------------------------------------- */
+		options: [
+			{
+				displayName: 'Caption',
+				name: 'caption',
+				type: 'string',
+				default: '',
+				description: 'The caption for the video post',
+			},
+			{
+				displayName: 'Privacy Level',
+				name: 'privacyLevel',
+				type: 'options',
+				options: [
+					{ name: 'Public', value: 'PUBLIC' },
+					{ name: 'Friends', value: 'FRIENDS' },
+					{ name: 'Private', value: 'PRIVATE' },
+				],
+				default: 'PUBLIC',
+				description: 'Who can view this post',
+			},
+			{
+				displayName: 'Schedule Time',
+				name: 'scheduleTime',
+				type: 'number',
+				default: 0,
+				description: 'UNIX timestamp for scheduled publication',
+			},
+			{
+				displayName: 'Tags',
+				name: 'tags',
+				type: 'string',
+				default: '',
+				description: 'Comma-separated list of tags for the video post',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'The title for the video post',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                videoPost:delete                            */
+	/* -------------------------------------------------------------------------- */
 	{
 		displayName: 'Video ID',
 		name: 'videoId',
@@ -123,55 +123,55 @@ export const videoPostFields: INodeProperties[] = [
 				operation: ['delete'],
 			},
 		},
-               description: 'The ID of the video to delete',
-       },
-       /* -------------------------------------------------------------------------- */
-       /*                              videoPost:analytics                           */
-       /* -------------------------------------------------------------------------- */
-       {
-               displayName: 'Video ID',
-               name: 'videoId',
-               type: 'string',
-               default: '',
-               required: true,
-               displayOptions: {
-                       show: {
-                               resource: ['videoPost'],
-                               operation: ['analytics'],
-                       },
-               },
-               description: 'The ID of the video to retrieve analytics for',
-       },
-       {
-               displayName: 'Metrics',
-               name: 'metrics',
-               type: 'multiOptions',
-               default: [],
-               required: true,
-               displayOptions: {
-                       show: {
-                               resource: ['videoPost'],
-                               operation: ['analytics'],
-                       },
-               },
-               options: [
-                       {
-                               name: 'Views',
-                               value: 'views',
-                       },
-                       {
-                               name: 'Likes',
-                               value: 'likes',
-                       },
-                       {
-                               name: 'Comments',
-                               value: 'comments',
-                       },
-                       {
-                               name: 'Shares',
-                               value: 'shares',
-                       },
-               ],
-               description: 'Select the metrics to retrieve',
-       },
+		description: 'The ID of the video to delete',
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                              videoPost:analytics                           */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Video ID',
+		name: 'videoId',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['analytics'],
+			},
+		},
+		description: 'The ID of the video to retrieve analytics for',
+	},
+	{
+		displayName: 'Metrics',
+		name: 'metrics',
+		type: 'multiOptions',
+		default: [],
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['analytics'],
+			},
+		},
+		options: [
+			{
+				name: 'Views',
+				value: 'views',
+			},
+			{
+				name: 'Likes',
+				value: 'likes',
+			},
+			{
+				name: 'Comments',
+				value: 'comments',
+			},
+			{
+				name: 'Shares',
+				value: 'shares',
+			},
+		],
+		description: 'Select the metrics to retrieve',
+	},
 ];


### PR DESCRIPTION
## Summary
- send video URL via PULL_FROM_URL and call `/post/publish/video/init/`
- default photo cover index to 0 to avoid invalid source info errors

## Testing
- `pnpm format`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ff765eb008324bedf547688246ef6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upload TikTok videos and photos via URL instead of local files.
  - Video upload input renamed to “Video URL,” reflecting the new URL-based workflow.
  - Video publishing flow updated to initialize uploads using the provided URL.
  - Photo publishing now pulls media from provided URLs with updated defaults.

- Documentation
  - Field label and description updated to guide users to provide a video URL instead of a file path.

- Notes
  - No changes to analytics or delete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->