### PR TITLE
chore: integrate prettier with eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,15 +10,17 @@ module.exports = {
 		node: true,
 	},
 
-	parser: '@typescript-eslint/parser',
+        parser: '@typescript-eslint/parser',
 
-	parserOptions: {
-		project: ['./tsconfig.json'],
-		sourceType: 'module',
-		extraFileExtensions: ['.json'],
-	},
+        parserOptions: {
+                project: ['./tsconfig.json'],
+                sourceType: 'module',
+                extraFileExtensions: ['.json'],
+        },
 
-	ignorePatterns: ['.eslintrc.js', '**/*.js', '**/node_modules/**', '**/dist/**'],
+	extends: ['plugin:prettier/recommended'],
+
+        ignorePatterns: ['.eslintrc.js', '**/*.js', '**/node_modules/**', '**/dist/**'],
 
 	overrides: [
 		{

--- a/nodes/TikTok/V2/GenericFunctions.ts
+++ b/nodes/TikTok/V2/GenericFunctions.ts
@@ -3,10 +3,10 @@ import type {
 	IExecuteFunctions,
 	IHookFunctions,
 	ILoadOptionsFunctions,
-        INodeParameterResourceLocator,
-        JsonObject,
-        IRequestOptions,
-        IHttpRequestMethods,
+	INodeParameterResourceLocator,
+	JsonObject,
+	IRequestOptions,
+	IHttpRequestMethods,
 } from 'n8n-workflow';
 import { ApplicationError, NodeApiError } from 'n8n-workflow';
 import { URL } from 'url';
@@ -44,13 +44,12 @@ export async function tiktokApiRequest(
 			const { data } = await this.helpers.requestOAuth2.call(this, 'tiktokOAuth2Api', options);
 			return data;
 		}
-        } catch (error) {
-                // Wrap unknown errors to avoid accessing properties on undefined
-                const errObject: JsonObject = error instanceof Error
-                        ? { message: error.message }
-                        : { message: String(error) };
-                throw new NodeApiError(this.getNode(), errObject);
-        }
+	} catch (error) {
+		// Wrap unknown errors to avoid accessing properties on undefined
+		const errObject: JsonObject =
+			error instanceof Error ? { message: error.message } : { message: String(error) };
+		throw new NodeApiError(this.getNode(), errObject);
+	}
 }
 
 export async function tiktokApiRequestAllItems(
@@ -93,17 +92,16 @@ export function returnId(contentId: INodeParameterResourceLocator) {
 			throw new ApplicationError('Not a valid TikTok URL', {
 				level: 'warning',
 				cause: error,
-				tags: {},   // Add an empty object or specific tags here
-				extra: {}   // Add any extra information here
-			  });
-			  
+				tags: {}, // Add an empty object or specific tags here
+				extra: {}, // Add any extra information here
+			});
 		}
 	} else {
-		throw new ApplicationError(`The mode ${contentId.mode} is not valid!`, { level: 'warning' ,
-			tags: {},   // Add an empty object or specific tags here
-			extra: {}   // Add any extra information here
-		  });
-		  
+		throw new ApplicationError(`The mode ${contentId.mode} is not valid!`, {
+			level: 'warning',
+			tags: {}, // Add an empty object or specific tags here
+			extra: {}, // Add any extra information here
+		});
 	}
 }
 
@@ -123,8 +121,8 @@ export async function returnIdFromUsername(
 	} else {
 		throw new ApplicationError(`The username mode ${usernameRlc.mode} is not valid!`, {
 			level: 'warning',
-			tags: {},   // Add an empty object or specific tags here
-			extra: {}   // Add any extra information here
-		  });
+			tags: {}, // Add an empty object or specific tags here
+			extra: {}, // Add any extra information here
+		});
 	}
 }

--- a/nodes/TikTok/V2/PhotoPostDescription.ts
+++ b/nodes/TikTok/V2/PhotoPostDescription.ts
@@ -12,144 +12,144 @@ export const photoPostOperations: INodeProperties[] = [
 			},
 		},
 		options: [
-                        {
-                                name: 'Upload',
-                                value: 'upload',
-                                description: 'Upload photos to TikTok',
-                                action: 'Upload photos',
-                        },
+			{
+				name: 'Upload',
+				value: 'upload',
+				description: 'Upload photos to TikTok',
+				action: 'Upload photos',
+			},
 		],
 		default: 'upload',
 	},
 ];
 
 export const photoPostFields: INodeProperties[] = [
-        /* -------------------------------------------------------------------------- */
-        /*                                photoPost:upload                            */
-        /* -------------------------------------------------------------------------- */
-        {
-                displayName: 'Photo URLs',
-                name: 'photoUrls',
-                type: 'string',
-                default: '',
-                required: true,
-                typeOptions: {
-                        multipleValues: true,
-                        multipleValueButtonText: 'Add URL',
-                },
-                displayOptions: {
-                        show: {
-                                resource: ['photoPost'],
-                                operation: ['upload'],
-                        },
-                },
-                description: 'Publicly accessible URLs of the photos to upload',
-        },
-        {
-                displayName: 'Cover Index',
-                name: 'photoCoverIndex',
-                type: 'number',
-                default: 0,
-                displayOptions: {
-                        show: {
-                                resource: ['photoPost'],
-                                operation: ['upload'],
-                        },
-                },
-                description: 'Index of the photo to use as the cover (starting from 0)',
-        },
-        {
-                displayName: 'Post Mode',
-                name: 'postMode',
-                type: 'options',
-                options: [
-                        {
-                                name: 'Direct Post',
-                                value: 'DIRECT_POST',
-                                description: "Directly post the content to the user's account",
-                        },
-                        {
-                                name: 'Media Upload',
-                                value: 'MEDIA_UPLOAD',
-                                description: 'Upload content for the user to finalize in TikTok',
-                        },
-                ],
-                default: 'MEDIA_UPLOAD',
-                displayOptions: {
-                        show: {
-                                resource: ['photoPost'],
-                                operation: ['upload'],
-                        },
-                },
-        },
-        {
-                displayName: 'Additional Fields',
-                name: 'additionalFields',
-                type: 'collection',
-                placeholder: 'Add Field',
-                default: {},
-                displayOptions: {
-                        show: {
-                                resource: ['photoPost'],
-                                operation: ['upload'],
-                        },
-                },
-                options: [
-                        {
-                                displayName: 'Auto Add Music',
-                                name: 'autoAddMusic',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether to automatically add recommended music to the photos',
-                        },
-                        {
-                                displayName: 'Brand Content Toggle',
-                                name: 'brandContentToggle',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether the content is a paid partnership to promote a third-party business',
-                        },
-                        {
-                                displayName: 'Brand Organic Toggle',
-                                name: 'brandOrganicToggle',
-                                type: 'boolean',
-                                default: false,
-                                description: "Whether the content promotes the creator's own business",
-                        },
-                        {
-                                displayName: 'Description',
-                                name: 'description',
-                                type: 'string',
-                                default: '',
-                                description: 'Description of the photo post',
-                        },
-                        {
-                                displayName: 'Disable Comment',
-                                name: 'disableComment',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether to disallow comments on this post',
-                        },
-                        {
-                                displayName: 'Privacy Level',
-                                name: 'privacyLevel',
-                                type: 'options',
-                                options: [
-                                        { name: 'Everyone', value: 'PUBLIC_TO_EVERYONE' },
-                                        { name: 'Mutual Followers', value: 'MUTUAL_FOLLOW_FRIENDS' },
-                                        { name: 'Followers of Creator', value: 'FOLLOWER_OF_CREATOR' },
-                                        { name: 'Only Me', value: 'SELF_ONLY' },
-                                ],
-                                default: 'PUBLIC_TO_EVERYONE',
-                                description: 'Who can view this post',
-                        },
-                        {
-                                displayName: 'Title',
-                                name: 'title',
-                                type: 'string',
-                                default: '',
-                                description: 'Title of the photo post',
-                        },
-                ],
-        },
+	/* -------------------------------------------------------------------------- */
+	/*                                photoPost:upload                            */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Photo URLs',
+		name: 'photoUrls',
+		type: 'string',
+		default: '',
+		required: true,
+		typeOptions: {
+			multipleValues: true,
+			multipleValueButtonText: 'Add URL',
+		},
+		displayOptions: {
+			show: {
+				resource: ['photoPost'],
+				operation: ['upload'],
+			},
+		},
+		description: 'Publicly accessible URLs of the photos to upload',
+	},
+	{
+		displayName: 'Cover Index',
+		name: 'photoCoverIndex',
+		type: 'number',
+		default: 0,
+		displayOptions: {
+			show: {
+				resource: ['photoPost'],
+				operation: ['upload'],
+			},
+		},
+		description: 'Index of the photo to use as the cover (starting from 0)',
+	},
+	{
+		displayName: 'Post Mode',
+		name: 'postMode',
+		type: 'options',
+		options: [
+			{
+				name: 'Direct Post',
+				value: 'DIRECT_POST',
+				description: "Directly post the content to the user's account",
+			},
+			{
+				name: 'Media Upload',
+				value: 'MEDIA_UPLOAD',
+				description: 'Upload content for the user to finalize in TikTok',
+			},
+		],
+		default: 'MEDIA_UPLOAD',
+		displayOptions: {
+			show: {
+				resource: ['photoPost'],
+				operation: ['upload'],
+			},
+		},
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['photoPost'],
+				operation: ['upload'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Auto Add Music',
+				name: 'autoAddMusic',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to automatically add recommended music to the photos',
+			},
+			{
+				displayName: 'Brand Content Toggle',
+				name: 'brandContentToggle',
+				type: 'boolean',
+				default: false,
+				description: 'Whether the content is a paid partnership to promote a third-party business',
+			},
+			{
+				displayName: 'Brand Organic Toggle',
+				name: 'brandOrganicToggle',
+				type: 'boolean',
+				default: false,
+				description: "Whether the content promotes the creator's own business",
+			},
+			{
+				displayName: 'Description',
+				name: 'description',
+				type: 'string',
+				default: '',
+				description: 'Description of the photo post',
+			},
+			{
+				displayName: 'Disable Comment',
+				name: 'disableComment',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to disallow comments on this post',
+			},
+			{
+				displayName: 'Privacy Level',
+				name: 'privacyLevel',
+				type: 'options',
+				options: [
+					{ name: 'Everyone', value: 'PUBLIC_TO_EVERYONE' },
+					{ name: 'Mutual Followers', value: 'MUTUAL_FOLLOW_FRIENDS' },
+					{ name: 'Followers of Creator', value: 'FOLLOWER_OF_CREATOR' },
+					{ name: 'Only Me', value: 'SELF_ONLY' },
+				],
+				default: 'PUBLIC_TO_EVERYONE',
+				description: 'Who can view this post',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'Title of the photo post',
+			},
+		],
+	},
 ];

--- a/nodes/TikTok/V2/PostStatusDescription.ts
+++ b/nodes/TikTok/V2/PostStatusDescription.ts
@@ -1,41 +1,41 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 export const postStatusOperations: INodeProperties[] = [
-  {
-    displayName: 'Operation',
-    name: 'operation',
-    type: 'options',
-    noDataExpression: true,
-    displayOptions: {
-      show: {
-        resource: ['postStatus'],
-      },
-    },
-    options: [
-      {
-        name: 'Get',
-        value: 'get',
-        description: 'Check the status of a post',
-        action: 'Get post status',
-      },
-    ],
-    default: 'get',
-  },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['postStatus'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Check the status of a post',
+				action: 'Get post status',
+			},
+		],
+		default: 'get',
+	},
 ];
 
 export const postStatusFields: INodeProperties[] = [
-  {
-    displayName: 'Publish ID',
-    name: 'publishId',
-    type: 'string',
-    default: '',
-    required: true,
-    displayOptions: {
-      show: {
-        resource: ['postStatus'],
-        operation: ['get'],
-      },
-    },
-    description: 'Identifier returned when initiating the post upload',
-  },
+	{
+		displayName: 'Publish ID',
+		name: 'publishId',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['postStatus'],
+				operation: ['get'],
+			},
+		},
+		description: 'Identifier returned when initiating the post upload',
+	},
 ];

--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -47,46 +47,46 @@ export class TikTokV2 implements INodeType {
 					type: 'options',
 					noDataExpression: true,
 					options: [
-                                                {
-                                                        name: 'Photo Post',
-                                                        value: 'photoPost',
-                                                        description: 'Upload a photo to TikTok',
-                                                },
-                                                {
-                                                        name: 'Post Status',
-                                                        value: 'postStatus',
-                                                        description: 'Check the status of a post',
-                                                },
-                                                {
-                                                        name: 'Search',
-                                                        value: 'search',
-                                                        description: 'Search for hashtags or sounds',
-                                                },
-                                                {
-                                                        name: 'User Profile',
-                                                        value: 'userProfile',
-                                                        description: 'Retrieve profile data of a TikTok user',
-                                                },
-                                                {
-                                                        name: 'Video Post',
-                                                        value: 'videoPost',
-                                                        description: 'Upload a video to TikTok',
-                                                },
-                                        ],
-                                        default: 'videoPost',
-                                },
+						{
+							name: 'Photo Post',
+							value: 'photoPost',
+							description: 'Upload a photo to TikTok',
+						},
+						{
+							name: 'Post Status',
+							value: 'postStatus',
+							description: 'Check the status of a post',
+						},
+						{
+							name: 'Search',
+							value: 'search',
+							description: 'Search for hashtags or sounds',
+						},
+						{
+							name: 'User Profile',
+							value: 'userProfile',
+							description: 'Retrieve profile data of a TikTok user',
+						},
+						{
+							name: 'Video Post',
+							value: 'videoPost',
+							description: 'Upload a video to TikTok',
+						},
+					],
+					default: 'videoPost',
+				},
 				// VIDEO POST
 				...videoPostOperations,
 				...videoPostFields,
-                                // PHOTO POST
-                                ...photoPostOperations,
-                                ...photoPostFields,
-                                // POST STATUS
-                                ...postStatusOperations,
-                                ...postStatusFields,
-                                // USER PROFILE
-                                ...userProfileOperations,
-                                ...userProfileFields,
+				// PHOTO POST
+				...photoPostOperations,
+				...photoPostFields,
+				// POST STATUS
+				...postStatusOperations,
+				...postStatusFields,
+				// USER PROFILE
+				...userProfileOperations,
+				...userProfileFields,
 				// SEARCH
 				...searchOperations,
 				...searchFields,
@@ -122,167 +122,178 @@ export class TikTokV2 implements INodeType {
 
 		for (let i = 0; i < length; i++) {
 			try {
-                               if (resource === 'videoPost') {
-                                       if (operation === 'upload') {
-                                               const source = this.getNodeParameter('source', i) as string;
-                                               const privacyLevel = this.getNodeParameter('privacyLevel', i) as string;
-                                               const additionalFields = this.getNodeParameter('additionalFields', i, {}) as IDataObject;
+				if (resource === 'videoPost') {
+					if (operation === 'upload') {
+						const source = this.getNodeParameter('source', i) as string;
+						const privacyLevel = this.getNodeParameter('privacyLevel', i) as string;
+						const additionalFields = this.getNodeParameter(
+							'additionalFields',
+							i,
+							{},
+						) as IDataObject;
 
-                                               const postInfo: IDataObject = {
-                                                       privacy_level: privacyLevel,
-                                               };
-                                               if (additionalFields.title) {
-                                                       postInfo.title = additionalFields.title as string;
-                                               }
-                                               if (additionalFields.disableDuet !== undefined) {
-                                                       postInfo.disable_duet = additionalFields.disableDuet as boolean;
-                                               }
-                                               if (additionalFields.disableStitch !== undefined) {
-                                                       postInfo.disable_stitch = additionalFields.disableStitch as boolean;
-                                               }
-                                               if (additionalFields.disableComment !== undefined) {
-                                                       postInfo.disable_comment = additionalFields.disableComment as boolean;
-                                               }
-                                               if (additionalFields.videoCoverTimestampMs !== undefined) {
-                                                       postInfo.video_cover_timestamp_ms = additionalFields.videoCoverTimestampMs as number;
-                                               }
-                                               if (additionalFields.brandContentToggle !== undefined) {
-                                                       postInfo.brand_content_toggle = additionalFields.brandContentToggle as boolean;
-                                               }
-                                               if (additionalFields.brandOrganicToggle !== undefined) {
-                                                       postInfo.brand_organic_toggle = additionalFields.brandOrganicToggle as boolean;
-                                               }
-                                               if (additionalFields.isAigc !== undefined) {
-                                                       postInfo.is_aigc = additionalFields.isAigc as boolean;
-                                               }
+						const postInfo: IDataObject = {
+							privacy_level: privacyLevel,
+						};
+						if (additionalFields.title) {
+							postInfo.title = additionalFields.title as string;
+						}
+						if (additionalFields.disableDuet !== undefined) {
+							postInfo.disable_duet = additionalFields.disableDuet as boolean;
+						}
+						if (additionalFields.disableStitch !== undefined) {
+							postInfo.disable_stitch = additionalFields.disableStitch as boolean;
+						}
+						if (additionalFields.disableComment !== undefined) {
+							postInfo.disable_comment = additionalFields.disableComment as boolean;
+						}
+						if (additionalFields.videoCoverTimestampMs !== undefined) {
+							postInfo.video_cover_timestamp_ms = additionalFields.videoCoverTimestampMs as number;
+						}
+						if (additionalFields.brandContentToggle !== undefined) {
+							postInfo.brand_content_toggle = additionalFields.brandContentToggle as boolean;
+						}
+						if (additionalFields.brandOrganicToggle !== undefined) {
+							postInfo.brand_organic_toggle = additionalFields.brandOrganicToggle as boolean;
+						}
+						if (additionalFields.isAigc !== undefined) {
+							postInfo.is_aigc = additionalFields.isAigc as boolean;
+						}
 
-                                               const sourceInfo: IDataObject = {
-                                                       source,
-                                               };
+						const sourceInfo: IDataObject = {
+							source,
+						};
 
-                                               if (source === 'PULL_FROM_URL') {
-                                                       const videoUrl = this.getNodeParameter('videoUrl', i) as string;
-                                                       sourceInfo.video_url = videoUrl;
-                                                       const body: IDataObject = {
-                                                               post_info: postInfo,
-                                                               source_info: sourceInfo,
-                                                       };
-                                                       responseData = await tiktokApiRequest.call(
-                                                               this,
-                                                               'POST',
-                                                               '/post/publish/video/init/',
-                                                               body,
-                                                       );
-                                               }
+						if (source === 'PULL_FROM_URL') {
+							const videoUrl = this.getNodeParameter('videoUrl', i) as string;
+							sourceInfo.video_url = videoUrl;
+							const body: IDataObject = {
+								post_info: postInfo,
+								source_info: sourceInfo,
+							};
+							responseData = await tiktokApiRequest.call(
+								this,
+								'POST',
+								'/post/publish/video/init/',
+								body,
+							);
+						}
 
-                                               if (source === 'FILE_UPLOAD') {
-                                                       const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
-                                                       const item = items[i].binary?.[binaryProperty];
-                                                       if (!item) {
-                                                               throw new NodeOperationError(this.getNode(), `No binary data property "${binaryProperty}" set`, { itemIndex: i });
-                                                       }
-                                                       const dataBuffer = Buffer.from(item.data, 'base64');
-                                                       sourceInfo.video_size = dataBuffer.length;
-                                                       sourceInfo.chunk_size = dataBuffer.length;
-                                                       sourceInfo.total_chunk_count = 1;
+						if (source === 'FILE_UPLOAD') {
+							const binaryProperty = this.getNodeParameter('binaryProperty', i) as string;
+							const item = items[i].binary?.[binaryProperty];
+							if (!item) {
+								throw new NodeOperationError(
+									this.getNode(),
+									`No binary data property "${binaryProperty}" set`,
+									{ itemIndex: i },
+								);
+							}
+							const dataBuffer = Buffer.from(item.data, 'base64');
+							sourceInfo.video_size = dataBuffer.length;
+							sourceInfo.chunk_size = dataBuffer.length;
+							sourceInfo.total_chunk_count = 1;
 
-                                                       const body: IDataObject = {
-                                                               post_info: postInfo,
-                                                               source_info: sourceInfo,
-                                                       };
-                                                       responseData = await tiktokApiRequest.call(
-                                                               this,
-                                                               'POST',
-                                                               '/post/publish/video/init/',
-                                                               body,
-                                                       );
+							const body: IDataObject = {
+								post_info: postInfo,
+								source_info: sourceInfo,
+							};
+							responseData = await tiktokApiRequest.call(
+								this,
+								'POST',
+								'/post/publish/video/init/',
+								body,
+							);
 
-                                                       const uploadUrl = (responseData as IDataObject).upload_url as string;
-                                                       if (!uploadUrl) {
-                                                               throw new NodeOperationError(this.getNode(), 'Upload URL not returned');
-                                                       }
+							const uploadUrl = (responseData as IDataObject).upload_url as string;
+							if (!uploadUrl) {
+								throw new NodeOperationError(this.getNode(), 'Upload URL not returned');
+							}
 
-                                                       await this.helpers.httpRequest({
-                                                               method: 'PUT',
-                                                               url: uploadUrl,
-                                                               body: dataBuffer,
-                                                               headers: {
-                                                                       'Content-Type': item.mimeType || 'video/mp4',
-                                                                       'Content-Length': dataBuffer.length,
-                                                                       'Content-Range': `bytes 0-${dataBuffer.length - 1}/${dataBuffer.length}`,
-                                                               },
-                                                               json: false,
-                                                       });
-                                               }
-                                       }
+							await this.helpers.httpRequest({
+								method: 'PUT',
+								url: uploadUrl,
+								body: dataBuffer,
+								headers: {
+									'Content-Type': item.mimeType || 'video/mp4',
+									'Content-Length': dataBuffer.length,
+									'Content-Range': `bytes 0-${dataBuffer.length - 1}/${dataBuffer.length}`,
+								},
+								json: false,
+							});
+						}
+					}
+				}
 
-                               }
+				if (resource === 'photoPost') {
+					if (operation === 'upload') {
+						const photoUrls = this.getNodeParameter('photoUrls', i) as string[];
+						const photoCoverIndex = this.getNodeParameter('photoCoverIndex', i) as number;
+						const postMode = this.getNodeParameter('postMode', i) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+						const postInfo: IDataObject = {};
+						if (additionalFields.title) {
+							postInfo.title = additionalFields.title as string;
+						}
+						if (additionalFields.description) {
+							postInfo.description = additionalFields.description as string;
+						}
+						if (additionalFields.privacyLevel) {
+							postInfo.privacy_level = additionalFields.privacyLevel as string;
+						}
+						if (additionalFields.disableComment !== undefined) {
+							postInfo.disable_comment = additionalFields.disableComment as boolean;
+						}
+						if (additionalFields.autoAddMusic !== undefined) {
+							postInfo.auto_add_music = additionalFields.autoAddMusic as boolean;
+						}
+						if (additionalFields.brandContentToggle !== undefined) {
+							postInfo.brand_content_toggle = additionalFields.brandContentToggle as boolean;
+						}
+						if (additionalFields.brandOrganicToggle !== undefined) {
+							postInfo.brand_organic_toggle = additionalFields.brandOrganicToggle as boolean;
+						}
+						if (postMode === 'DIRECT_POST' && postInfo.privacy_level === undefined) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Privacy Level must be set for Direct Post',
+								{ itemIndex: i },
+							);
+						}
+						const body: IDataObject = {
+							post_info: postInfo,
+							source_info: {
+								source: 'PULL_FROM_URL',
+								photo_cover_index: photoCoverIndex,
+								photo_images: photoUrls,
+							},
+							post_mode: postMode,
+							media_type: 'PHOTO',
+						};
+						responseData = await tiktokApiRequest.call(
+							this,
+							'POST',
+							'/post/publish/content/init/',
+							body,
+						);
+					}
+				}
 
-                                if (resource === 'photoPost') {
-                                        if (operation === 'upload') {
-                                                const photoUrls = this.getNodeParameter('photoUrls', i) as string[];
-                                                const photoCoverIndex = this.getNodeParameter('photoCoverIndex', i) as number;
-                                                const postMode = this.getNodeParameter('postMode', i) as string;
-                                                const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
-                                                const postInfo: IDataObject = {};
-                                                if (additionalFields.title) {
-                                                        postInfo.title = additionalFields.title as string;
-                                                }
-                                                if (additionalFields.description) {
-                                                        postInfo.description = additionalFields.description as string;
-                                                }
-                                                if (additionalFields.privacyLevel) {
-                                                        postInfo.privacy_level = additionalFields.privacyLevel as string;
-                                                }
-                                                if (additionalFields.disableComment !== undefined) {
-                                                        postInfo.disable_comment = additionalFields.disableComment as boolean;
-                                                }
-                                                if (additionalFields.autoAddMusic !== undefined) {
-                                                        postInfo.auto_add_music = additionalFields.autoAddMusic as boolean;
-                                                }
-                                                if (additionalFields.brandContentToggle !== undefined) {
-                                                        postInfo.brand_content_toggle = additionalFields.brandContentToggle as boolean;
-                                                }
-                                                if (additionalFields.brandOrganicToggle !== undefined) {
-                                                        postInfo.brand_organic_toggle = additionalFields.brandOrganicToggle as boolean;
-                                                }
-                                                if (postMode === 'DIRECT_POST' && postInfo.privacy_level === undefined) {
-                                                        throw new NodeOperationError(this.getNode(), 'Privacy Level must be set for Direct Post', { itemIndex: i });
-                                                }
-                                                const body: IDataObject = {
-                                                        post_info: postInfo,
-                                                        source_info: {
-                                                                source: 'PULL_FROM_URL',
-                                                                photo_cover_index: photoCoverIndex,
-                                                                photo_images: photoUrls,
-                                                        },
-                                                        post_mode: postMode,
-                                                        media_type: 'PHOTO',
-                                                };
-                                                responseData = await tiktokApiRequest.call(
-                                                        this,
-                                                        'POST',
-                                                        '/post/publish/content/init/',
-                                                        body,
-                                                );
-                                        }
-                                }
+				if (resource === 'postStatus') {
+					if (operation === 'get') {
+						const publishId = this.getNodeParameter('publishId', i) as string;
+						const body = { publish_id: publishId } as IDataObject;
+						responseData = await tiktokApiRequest.call(
+							this,
+							'POST',
+							'/post/publish/status/fetch/',
+							body,
+						);
+					}
+				}
 
-                                if (resource === 'postStatus') {
-                                        if (operation === 'get') {
-                                                const publishId = this.getNodeParameter('publishId', i) as string;
-                                                const body = { publish_id: publishId } as IDataObject;
-                                                responseData = await tiktokApiRequest.call(
-                                                        this,
-                                                        'POST',
-                                                        '/post/publish/status/fetch/',
-                                                        body,
-                                                );
-                                        }
-                                }
-
-                                if (resource === 'search') {
-                                        const query = this.getNodeParameter('query', i) as string;
+				if (resource === 'search') {
+					const query = this.getNodeParameter('query', i) as string;
 					const cursor = this.getNodeParameter('cursor', i, 0) as number;
 					const limit = this.getNodeParameter('limit', i, 20) as number;
 					const qs: IDataObject = { keyword: query, cursor, max_count: limit };

--- a/nodes/TikTok/V2/UserProfileDescription.ts
+++ b/nodes/TikTok/V2/UserProfileDescription.ts
@@ -1,120 +1,120 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 export const userProfileOperations: INodeProperties[] = [
-        {
-                displayName: 'Operation',
-                name: 'operation',
-                type: 'options',
-                noDataExpression: true,
-                required: true,
-                displayOptions: {
-                        show: {
-                                resource: ['userProfile'],
-                        },
-                },
-                options: [
-                        {
-                                name: 'Get User Information',
-                                value: 'get',
-                                description: 'Get profile information for the authenticated user',
-                                action: 'Get user information',
-                        },
-                        {
-                                name: 'Analytics',
-                                value: 'analytics',
-                                description: 'Get analytics metrics for the authenticated user',
-                                action: 'Get analytics',
-                        },
-                ],
-                default: 'get',
-        },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['userProfile'],
+			},
+		},
+		options: [
+			{
+				name: 'Get User Information',
+				value: 'get',
+				description: 'Get profile information for the authenticated user',
+				action: 'Get user information',
+			},
+			{
+				name: 'Analytics',
+				value: 'analytics',
+				description: 'Get analytics metrics for the authenticated user',
+				action: 'Get analytics',
+			},
+		],
+		default: 'get',
+	},
 ];
 
 export const userProfileFields: INodeProperties[] = [
-        /* -------------------------------------------------------------------------- */
-        /*                                userProfile:get                             */
-        /* -------------------------------------------------------------------------- */
-        {
-                displayName: 'Fields',
-                name: 'fields',
-                type: 'multiOptions',
-                default: [],
-                required: true,
-                displayOptions: {
-                        show: {
-                                resource: ['userProfile'],
-                                operation: ['get'],
-                        },
-                },
-                description: 'Select the profile fields to include in the response',
-                options: [
-                        {
-                                name: 'Avatar URL',
-                                value: 'avatar_url',
-                        },
-                        {
-                                name: 'Bio Description',
-                                value: 'bio_description',
-                        },
-                        {
-                                name: 'Display Name',
-                                value: 'display_name',
-                        },
-                        {
-                                name: 'Follower Count',
-                                value: 'follower_count',
-                        },
-                        {
-                                name: 'Following Count',
-                                value: 'following_count',
-                        },
-                        {
-                                name: 'Likes Count',
-                                value: 'likes_count',
-                        },
-                        {
-                                name: 'Profile Deep Link',
-                                value: 'profile_deep_link',
-                        },
-                        {
-                                name: 'Username',
-                                value: 'username',
-                        },
-                        {
-                                name: 'Video Count',
-                                value: 'video_count',
-                        },
-                ],
-        },
-        /* -------------------------------------------------------------------------- */
-        /*                                userProfile:analytics                       */
-        /* -------------------------------------------------------------------------- */
-        {
-                displayName: 'Metrics',
-                name: 'metrics',
-                type: 'multiOptions',
-                default: [],
-                required: true,
-                displayOptions: {
-                        show: {
-                                resource: ['userProfile'],
-                                operation: ['analytics'],
-                        },
-                },
-                description: 'Select the analytics metrics to include in the response',
-                options: [
-                        {
-                                name: 'Followers',
-                                value: 'followers',
-                        },
-                        {
-                                name: 'Likes',
-                                value: 'likes',
-                        },
-                        {
-                                name: 'Views',
-                                value: 'views',
-                        },
-                ],
-        },
+	/* -------------------------------------------------------------------------- */
+	/*                                userProfile:get                             */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Fields',
+		name: 'fields',
+		type: 'multiOptions',
+		default: [],
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['userProfile'],
+				operation: ['get'],
+			},
+		},
+		description: 'Select the profile fields to include in the response',
+		options: [
+			{
+				name: 'Avatar URL',
+				value: 'avatar_url',
+			},
+			{
+				name: 'Bio Description',
+				value: 'bio_description',
+			},
+			{
+				name: 'Display Name',
+				value: 'display_name',
+			},
+			{
+				name: 'Follower Count',
+				value: 'follower_count',
+			},
+			{
+				name: 'Following Count',
+				value: 'following_count',
+			},
+			{
+				name: 'Likes Count',
+				value: 'likes_count',
+			},
+			{
+				name: 'Profile Deep Link',
+				value: 'profile_deep_link',
+			},
+			{
+				name: 'Username',
+				value: 'username',
+			},
+			{
+				name: 'Video Count',
+				value: 'video_count',
+			},
+		],
+	},
+	/* -------------------------------------------------------------------------- */
+	/*                                userProfile:analytics                       */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Metrics',
+		name: 'metrics',
+		type: 'multiOptions',
+		default: [],
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['userProfile'],
+				operation: ['analytics'],
+			},
+		},
+		description: 'Select the analytics metrics to include in the response',
+		options: [
+			{
+				name: 'Followers',
+				value: 'followers',
+			},
+			{
+				name: 'Likes',
+				value: 'likes',
+			},
+			{
+				name: 'Views',
+				value: 'views',
+			},
+		],
+	},
 ];

--- a/nodes/TikTok/V2/VideoPostDescription.ts
+++ b/nodes/TikTok/V2/VideoPostDescription.ts
@@ -1,173 +1,173 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 export const videoPostOperations: INodeProperties[] = [
-        {
-                displayName: 'Operation',
-                name: 'operation',
-                type: 'options',
-                noDataExpression: true,
-                displayOptions: {
-                        show: {
-                                resource: ['videoPost'],
-                        },
-                },
-                options: [
-                        {
-                                name: 'Upload',
-                                value: 'upload',
-                                description: 'Upload a video to TikTok',
-                                action: 'Upload video',
-                        },
-                ],
-                default: 'upload',
-        },
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+			},
+		},
+		options: [
+			{
+				name: 'Upload',
+				value: 'upload',
+				description: 'Upload a video to TikTok',
+				action: 'Upload video',
+			},
+		],
+		default: 'upload',
+	},
 ];
 
 export const videoPostFields: INodeProperties[] = [
-        /* -------------------------------------------------------------------------- */
-        /*                                videoPost:upload                            */
-        /* -------------------------------------------------------------------------- */
-        {
-                displayName: 'Source',
-                name: 'source',
-                type: 'options',
-                options: [
-                        {
-                                name: 'Upload From URL',
-                                value: 'PULL_FROM_URL',
-                        },
-                        {
-                                name: 'Upload File',
-                                value: 'FILE_UPLOAD',
-                        },
-                ],
-                default: 'PULL_FROM_URL',
-                displayOptions: {
-                        show: {
-                                resource: ['videoPost'],
-                                operation: ['upload'],
-                        },
-                },
-        },
-        {
-                displayName: 'Video URL',
-                name: 'videoUrl',
-                type: 'string',
-                default: '',
-                required: true,
-                displayOptions: {
-                        show: {
-                                resource: ['videoPost'],
-                                operation: ['upload'],
-                                source: ['PULL_FROM_URL'],
-                        },
-                },
-                description: 'Publicly accessible URL from which TikTok will pull the video',
-        },
-        {
-                displayName: 'Binary Property',
-                name: 'binaryProperty',
-                type: 'string',
-                default: 'data',
-                required: true,
-                displayOptions: {
-                        show: {
-                                resource: ['videoPost'],
-                                operation: ['upload'],
-                                source: ['FILE_UPLOAD'],
-                        },
-                },
-                description: 'Name of the binary property containing the video file to upload',
-        },
-        {
-                displayName: 'Privacy Level',
-                name: 'privacyLevel',
-                type: 'options',
-                options: [
-                        { name: 'Everyone', value: 'PUBLIC_TO_EVERYONE' },
-                        { name: 'Mutual Followers', value: 'MUTUAL_FOLLOW_FRIENDS' },
-                        { name: 'Followers of Creator', value: 'FOLLOWER_OF_CREATOR' },
-                        { name: 'Only Me', value: 'SELF_ONLY' },
-                ],
-                default: 'PUBLIC_TO_EVERYONE',
-                required: true,
-                displayOptions: {
-                        show: {
-                                resource: ['videoPost'],
-                                operation: ['upload'],
-                        },
-                },
-                description: 'Who can view this post',
-        },
-        {
-                displayName: 'Additional Fields',
-                name: 'additionalFields',
-                type: 'collection',
-                placeholder: 'Add Field',
-                default: {},
-                displayOptions: {
-                        show: {
-                                resource: ['videoPost'],
-                                operation: ['upload'],
-                        },
-                },
-                options: [
-                        {
-                                displayName: 'Brand Content Toggle',
-                                name: 'brandContentToggle',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether the video promotes a third-party business',
-                        },
-                        {
-                                displayName: 'Brand Organic Toggle',
-                                name: 'brandOrganicToggle',
-                                type: 'boolean',
-                                default: false,
-                                description: "Whether the video promotes the creator's own business",
-                        },
-                        {
-                                displayName: 'Disable Comment',
-                                name: 'disableComment',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether to disallow comments on this post',
-                        },
-                        {
-                                displayName: 'Disable Duet',
-                                name: 'disableDuet',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether to disallow Duets for this post',
-                        },
-                        {
-                                displayName: 'Disable Stitch',
-                                name: 'disableStitch',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether to disallow Stitches for this post',
-                        },
-                        {
-                                displayName: 'Is AI Generated',
-                                name: 'isAigc',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether the video is AI generated content',
-                        },
-                        {
-                                displayName: 'Title',
-                                name: 'title',
-                                type: 'string',
-                                default: '',
-                                description: 'Caption for the video',
-                        },
-                        {
-                                displayName: 'Video Cover Timestamp (MS)',
-                                name: 'videoCoverTimestampMs',
-                                type: 'number',
-                                default: 0,
-                                description: 'Frame timestamp in milliseconds to use as the video cover',
-                        },
-                ],
-        },
+	/* -------------------------------------------------------------------------- */
+	/*                                videoPost:upload                            */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Source',
+		name: 'source',
+		type: 'options',
+		options: [
+			{
+				name: 'Upload From URL',
+				value: 'PULL_FROM_URL',
+			},
+			{
+				name: 'Upload File',
+				value: 'FILE_UPLOAD',
+			},
+		],
+		default: 'PULL_FROM_URL',
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['upload'],
+			},
+		},
+	},
+	{
+		displayName: 'Video URL',
+		name: 'videoUrl',
+		type: 'string',
+		default: '',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['upload'],
+				source: ['PULL_FROM_URL'],
+			},
+		},
+		description: 'Publicly accessible URL from which TikTok will pull the video',
+	},
+	{
+		displayName: 'Binary Property',
+		name: 'binaryProperty',
+		type: 'string',
+		default: 'data',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['upload'],
+				source: ['FILE_UPLOAD'],
+			},
+		},
+		description: 'Name of the binary property containing the video file to upload',
+	},
+	{
+		displayName: 'Privacy Level',
+		name: 'privacyLevel',
+		type: 'options',
+		options: [
+			{ name: 'Everyone', value: 'PUBLIC_TO_EVERYONE' },
+			{ name: 'Mutual Followers', value: 'MUTUAL_FOLLOW_FRIENDS' },
+			{ name: 'Followers of Creator', value: 'FOLLOWER_OF_CREATOR' },
+			{ name: 'Only Me', value: 'SELF_ONLY' },
+		],
+		default: 'PUBLIC_TO_EVERYONE',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['upload'],
+			},
+		},
+		description: 'Who can view this post',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['videoPost'],
+				operation: ['upload'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Brand Content Toggle',
+				name: 'brandContentToggle',
+				type: 'boolean',
+				default: false,
+				description: 'Whether the video promotes a third-party business',
+			},
+			{
+				displayName: 'Brand Organic Toggle',
+				name: 'brandOrganicToggle',
+				type: 'boolean',
+				default: false,
+				description: "Whether the video promotes the creator's own business",
+			},
+			{
+				displayName: 'Disable Comment',
+				name: 'disableComment',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to disallow comments on this post',
+			},
+			{
+				displayName: 'Disable Duet',
+				name: 'disableDuet',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to disallow Duets for this post',
+			},
+			{
+				displayName: 'Disable Stitch',
+				name: 'disableStitch',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to disallow Stitches for this post',
+			},
+			{
+				displayName: 'Is AI Generated',
+				name: 'isAigc',
+				type: 'boolean',
+				default: false,
+				description: 'Whether the video is AI generated content',
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'Caption for the video',
+			},
+			{
+				displayName: 'Video Cover Timestamp (MS)',
+				name: 'videoCoverTimestampMs',
+				type: 'number',
+				default: 0,
+				description: 'Frame timestamp in milliseconds to use as the video cover',
+			},
+		],
+	},
 ];

--- a/package.json
+++ b/package.json
@@ -1,70 +1,72 @@
 {
-  "name": "@igabm/n8n-nodes-tiktok",
-  "version": "1.4.0",
-  "description": "n8n nodes for implementation for TikTok API",
-  "keywords": [
-    "n8n-community-node-package"
-  ],
-  "license": "MIT",
-  "homepage": "https://github.com/igabm/",
-  "author": {
-    "name": "Gabriel MATIAS",
-    "email": "dev.gabriel.matias@gmail.com"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/igabm/n8n-nodes-tiktok.git"
-  },
-  "engines": {
-    "node": ">=18.10",
-    "pnpm": ">=9.1"
-  },
-  "packageManager": "pnpm@10.2.0",
-  "main": "index.js",
-  "scripts": {
-    "preinstall": "npx only-allow pnpm",
-    "build": "tsc && gulp build:icons",
-    "dev": "tsc --watch",
-    "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes credentials package.json",
-    "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "pnpm build && pnpm lint -c .eslintrc.prepublish.js nodes credentials package.json",
-    "release": "semantic-release"
-  },
-  "files": [
-    "dist"
-  ],
-  "n8n": {
-    "n8nNodesApiVersion": 1,
-    "minimumCoreVersion": "1.107.0",
-    "credentials": [
-      "dist/credentials/TikTokOAuth2Api.credentials.js"
-    ],
-    "nodes": [
-      "dist/nodes/TikTok/Tiktok.node.js"
-    ]
-  },
-  "devDependencies": {
-    "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/commit-analyzer": "^13.0.1",
-    "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^11.0.4",
-    "@semantic-release/npm": "^12.0.2",
-    "@semantic-release/release-notes-generator": "^14.0.3",
-    "@types/node": "^22.13.1",
-    "@typescript-eslint/parser": "~8.32.0",
-    "eslint": "^8.57.0",
-    "eslint-plugin-n8n-nodes-base": "^1.16.3",
-    "gulp": "^5.0.0",
-    "n8n-workflow": "*",
-    "prettier": "^3.5.3",
-    "semantic-release": "^24.2.7",
-    "typescript": "~5.8.2"
-  },
-  "peerDependencies": {
-    "n8n-workflow": "*"
-  },
-  "bugs": {
-    "url": "https://github.com/igabm/n8n-nodes-tiktok/issues"
-  }
+	"name": "@igabm/n8n-nodes-tiktok",
+	"version": "1.4.0",
+	"description": "n8n nodes for implementation for TikTok API",
+	"keywords": [
+		"n8n-community-node-package"
+	],
+	"license": "MIT",
+	"homepage": "https://github.com/igabm/",
+	"author": {
+		"name": "Gabriel MATIAS",
+		"email": "dev.gabriel.matias@gmail.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/igabm/n8n-nodes-tiktok.git"
+	},
+	"engines": {
+		"node": ">=18.10",
+		"pnpm": ">=9.1"
+	},
+	"packageManager": "pnpm@10.2.0",
+	"main": "index.js",
+	"scripts": {
+		"preinstall": "npx only-allow pnpm",
+		"build": "tsc && gulp build:icons",
+		"dev": "tsc --watch",
+		"format": "prettier nodes credentials --write",
+		"lint": "eslint nodes credentials package.json",
+		"lintfix": "eslint nodes credentials package.json --fix",
+		"prepublishOnly": "pnpm build && pnpm lint -c .eslintrc.prepublish.js nodes credentials package.json",
+		"release": "semantic-release"
+	},
+	"files": [
+		"dist"
+	],
+	"n8n": {
+		"n8nNodesApiVersion": 1,
+		"minimumCoreVersion": "1.107.0",
+		"credentials": [
+			"dist/credentials/TikTokOAuth2Api.credentials.js"
+		],
+		"nodes": [
+			"dist/nodes/TikTok/Tiktok.node.js"
+		]
+	},
+	"devDependencies": {
+		"@semantic-release/changelog": "^6.0.3",
+		"@semantic-release/commit-analyzer": "^13.0.1",
+		"@semantic-release/git": "^10.0.1",
+		"@semantic-release/github": "^11.0.4",
+		"@semantic-release/npm": "^12.0.2",
+		"@semantic-release/release-notes-generator": "^14.0.3",
+		"@types/node": "^22.13.1",
+		"@typescript-eslint/parser": "~8.32.0",
+		"eslint": "^8.57.0",
+		"eslint-config-prettier": "^10.1.8",
+		"eslint-plugin-n8n-nodes-base": "^1.16.3",
+		"eslint-plugin-prettier": "^5.5.4",
+		"gulp": "^5.0.0",
+		"n8n-workflow": "*",
+		"prettier": "^3.5.3",
+		"semantic-release": "^24.2.7",
+		"typescript": "~5.8.2"
+	},
+	"peerDependencies": {
+		"n8n-workflow": "*"
+	},
+	"bugs": {
+		"url": "https://github.com/igabm/n8n-nodes-tiktok/issues"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,15 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@8.57.1)
       eslint-plugin-n8n-nodes-base:
         specifier: ^1.16.3
         version: 1.16.3(eslint@8.57.1)(typescript@5.8.3)
+      eslint-plugin-prettier:
+        specifier: ^5.5.4
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.6.2)
       gulp:
         specifier: ^5.0.0
         version: 5.0.0
@@ -176,6 +182,10 @@ packages:
 
   '@octokit/types@14.1.0':
     resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -707,6 +717,12 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-config-riot@1.0.0:
     resolution: {integrity: sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==}
 
@@ -716,6 +732,20 @@ packages:
   eslint-plugin-n8n-nodes-base@1.16.3:
     resolution: {integrity: sha512-edLX42Vg4B+y0kzkitTVDmHZQrG5/wUZO874N5Z9leBuxt5TG1pqMY4zdr35RlpM4p4REr/T9x+6DpsQSL63WA==}
     engines: {node: '>=20.15', pnpm: '>=9.6'}
+
+  eslint-plugin-prettier@5.5.4:
+    resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -789,6 +819,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -1836,6 +1869,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-linter-helpers@1.0.0:
+    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
+    engines: {node: '>=6.0.0'}
+
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
@@ -2131,6 +2168,10 @@ packages:
 
   sver@1.8.4:
     resolution: {integrity: sha512-71o1zfzyawLfIWBOmw8brleKyvnbn73oVHNCsu51uPMz/HWiKkkXsI31JjHW5zqXEqnPYkIiHd8ZmL7FCimLEA==}
+
+  synckit@0.11.11:
+    resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -2522,6 +2563,8 @@ snapshots:
   '@octokit/types@14.1.0':
     dependencies:
       '@octokit/openapi-types': 25.1.0
+
+  '@pkgr/core@0.2.9': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -3144,6 +3187,10 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-config-prettier@10.1.8(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
   eslint-config-riot@1.0.0: {}
 
   eslint-plugin-local@1.0.0: {}
@@ -3162,6 +3209,15 @@ snapshots:
       - eslint
       - supports-color
       - typescript
+
+  eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.6.2):
+    dependencies:
+      eslint: 8.57.1
+      prettier: 3.6.2
+      prettier-linter-helpers: 1.0.0
+      synckit: 0.11.11
+    optionalDependencies:
+      eslint-config-prettier: 10.1.8(eslint@8.57.1)
 
   eslint-scope@7.2.2:
     dependencies:
@@ -3285,6 +3341,8 @@ snapshots:
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
 
   fast-fifo@1.3.2: {}
 
@@ -4228,6 +4286,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier-linter-helpers@1.0.0:
+    dependencies:
+      fast-diff: 1.3.0
+
   prettier@3.6.2: {}
 
   pretty-ms@9.2.0:
@@ -4556,6 +4618,10 @@ snapshots:
   sver@1.8.4:
     optionalDependencies:
       semver: 6.3.1
+
+  synckit@0.11.11:
+    dependencies:
+      '@pkgr/core': 0.2.9
 
   teex@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- enable Prettier enforcement via ESLint so `pnpm lintfix` formats files automatically
- add Prettier-related ESLint plugins and reformat existing node files

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a072a6b7088324a9d15c2bdc4f1387