### PR TITLE
fix: correct TikTok search endpoints

### DIFF
--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -296,13 +296,13 @@ export class TikTokV2 implements INodeType {
 					const query = this.getNodeParameter('query', i) as string;
 					const cursor = this.getNodeParameter('cursor', i, 0) as number;
 					const limit = this.getNodeParameter('limit', i, 20) as number;
-					const qs: IDataObject = { keyword: query, cursor, max_count: limit };
+					const qs: IDataObject = { query, cursor, max_count: limit };
 					if (operation === 'hashtag') {
-						responseData = await tiktokApiRequest.call(this, 'GET', '/search/hashtag/', {}, qs);
+						responseData = await tiktokApiRequest.call(this, 'GET', '/hashtag/search/', {}, qs);
 						responseData = responseData.hashtags ?? responseData.results ?? responseData;
 					}
 					if (operation === 'sound') {
-						responseData = await tiktokApiRequest.call(this, 'GET', '/search/sound/', {}, qs);
+						responseData = await tiktokApiRequest.call(this, 'GET', '/sound/search/', {}, qs);
 						responseData = responseData.sounds ?? responseData.results ?? responseData;
 					}
 				}


### PR DESCRIPTION
## Summary
- use `/hashtag/search/` and `/sound/search/` paths for search
- pass `query` to new endpoints

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a1a5a912f08324bf44eb6e0dedcca5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized search input across TikTok V2 hashtag and sound searches; pagination behavior remains unchanged.
- Improvements
  - Consistent results mapping for hashtag and sound searches; error handling and overall flow unaffected.
- Chores
  - Updated underlying integration to align with recent platform changes; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->