### PR TITLE
feat: support comma-separated photo URLs

### DIFF
--- a/nodes/TikTok/V2/PhotoPostDescription.ts
+++ b/nodes/TikTok/V2/PhotoPostDescription.ts
@@ -33,17 +33,14 @@ export const photoPostFields: INodeProperties[] = [
 		type: 'string',
 		default: '',
 		required: true,
-		typeOptions: {
-			multipleValues: true,
-			multipleValueButtonText: 'Add URL',
-		},
 		displayOptions: {
 			show: {
 				resource: ['photoPost'],
 				operation: ['upload'],
 			},
 		},
-		description: 'Publicly accessible URLs of the photos to upload',
+		description:
+			'Publicly accessible URLs of the photos to upload. Provide a single URL or a comma-separated list of URLs.',
 	},
 	{
 		displayName: 'Cover Index',

--- a/nodes/TikTok/V2/TikTokV2.node.ts
+++ b/nodes/TikTok/V2/TikTokV2.node.ts
@@ -227,7 +227,13 @@ export class TikTokV2 implements INodeType {
 
 				if (resource === 'photoPost') {
 					if (operation === 'upload') {
-						const photoUrls = this.getNodeParameter('photoUrls', i) as string[];
+						let photoUrls = this.getNodeParameter('photoUrls', i) as string | string[];
+						if (typeof photoUrls === 'string') {
+							photoUrls = photoUrls
+								.split(',')
+								.map((url) => url.trim())
+								.filter((url) => url);
+						}
 						const photoCoverIndex = this.getNodeParameter('photoCoverIndex', i) as number;
 						const postMode = this.getNodeParameter('postMode', i) as string;
 						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;


### PR DESCRIPTION
## Summary
- allow photo post URL field to accept a single URL or comma-separated list
- parse comma-separated photo URLs before upload

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a37c22451483248a512300cfe2b89c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Photo Post: You can now enter multiple photo URLs in a single field using a comma-separated list, or a single URL. The input supports flexible formatting and ignores extra spaces.

- Documentation
  - Updated the Photo URLs field description to clearly state support for a single URL or a comma-separated list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->