### PR TITLE
ci: modernize GitHub Actions workflow for n8n node package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,58 +3,98 @@ name: CI
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Lint and Build
+  validate:
+    name: Validate (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm lint
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
         env:
           ESLINT_USE_FLAT_CONFIG: 'false'
-      - run: pnpm build
+
+      - name: Build
+        run: pnpm build
 
   release:
-    needs: test
+    name: Release
+    needs: validate
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - run: pnpm lint
+          version: 10.2.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Lint
+        run: pnpm lint
         env:
           ESLINT_USE_FLAT_CONFIG: 'false'
-      - run: npx semantic-release
+
+      - name: Publish release
+        run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Motivation

- The repository's CI was failing and only triggered on `master`, which breaks runs for repos using `main` as default, so the workflow was modernized to a current Node/pnpm setup to reduce such failures.
- Align the workflow with the project's declared tooling by pinning `pnpm` and using a modern Node matrix to avoid runtime mismatches.

### Description

- Updated `.github/workflows/release.yml` to trigger on both `main` and `master` and added `permissions: contents: read` for safer default access.
- Renamed the `test` job to `validate`, set `fail-fast: false`, and changed the Node matrix to `20.x` and `22.x` while adding `cache-dependency-path: pnpm-lock.yaml` to `actions/setup-node`.
- Added an explicit `pnpm/action-setup@v4` step pinned to `10.2.0`, and split steps into `Install dependencies`, `Lint`, and `Build` with deterministic `pnpm install --frozen-lockfile` usage.
- Modernized the `release` job with explicit `if` for pushes to `main`/`master`, kept scoped permissions, mirrored the `pnpm`/Node setup, and switched to `pnpm exec semantic-release` for publishing.

### Testing

- Ran `pnpm lint` locally and it succeeded without errors.
- Ran `pnpm build` locally and it completed successfully (TypeScript compilation and `gulp build:icons`).
- Attempted `pnpm dlx actionlint .github/workflows/release.yml` but `pnpm dlx` reported `No binaries found in actionlint`, so `actionlint` was not executed via `pnpm dlx` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ad113f10c8324836acb3b75fdad67)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version support to 20.x and 22.x (dropped 18.x support)
  * Improved build and release workflow infrastructure for enhanced reliability and clarity
  * Updated pnpm to version 10.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->